### PR TITLE
Define rty::Formula and replace UnboundAssumption and Refinement with it

### DIFF
--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -767,7 +767,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
 #[derive(Debug, Clone)]
 pub struct UnbindAtoms<T> {
     existentials: IndexVec<rty::ExistentialVarIdx, chc::Sort>,
-    formula: rty::FormulaWithAtoms<rty::RefinedTypeVar<Var>>,
+    formula: chc::Body<rty::RefinedTypeVar<Var>>,
     target_equations: Vec<(rty::RefinedTypeVar<T>, chc::Term<rty::RefinedTypeVar<Var>>)>,
 }
 

--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -16,7 +16,9 @@ use crate::refine::{
     self, BasicBlockType, Env, PlaceType, PlaceTypeVar, TempVarIdx, TemplateTypeGenerator,
     UnboundAssumption, UnrefinedTypeGenerator, Var,
 };
-use crate::rty::{self, ClauseBuilderExt as _, ClauseScope as _, Subtyping as _};
+use crate::rty::{
+    self, ClauseBuilderExt as _, ClauseScope as _, ShiftExistential as _, Subtyping as _,
+};
 
 mod drop_point;
 mod visitor;
@@ -767,7 +769,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
 #[derive(Debug, Clone)]
 pub struct UnbindAtoms<T> {
     existentials: IndexVec<rty::ExistentialVarIdx, chc::Sort>,
-    formula: chc::Body<rty::RefinedTypeVar<Var>>,
+    body: chc::Body<rty::RefinedTypeVar<Var>>,
     target_equations: Vec<(rty::RefinedTypeVar<T>, chc::Term<rty::RefinedTypeVar<Var>>)>,
 }
 
@@ -775,7 +777,7 @@ impl<T> Default for UnbindAtoms<T> {
     fn default() -> Self {
         UnbindAtoms {
             existentials: Default::default(),
-            formula: Default::default(),
+            body: Default::default(),
             target_equations: Default::default(),
         }
     }
@@ -783,7 +785,7 @@ impl<T> Default for UnbindAtoms<T> {
 
 impl<T> UnbindAtoms<T> {
     pub fn push(&mut self, target: rty::RefinedTypeVar<T>, var_ty: PlaceType) {
-        self.formula.push_conj(
+        self.body.push_conj(
             var_ty
                 .formula
                 .map_var(|v| v.shift_existential(self.existentials.len()).into()),
@@ -802,13 +804,10 @@ impl<T> UnbindAtoms<T> {
             ty: src_ty,
             refinement,
         } = ty;
-        let rty::Refinement {
-            existentials,
-            formula,
-        } = refinement;
+        let rty::Refinement { existentials, body } = refinement;
 
-        self.formula
-            .push_conj(formula.map_var(|v| v.shift_existential(self.existentials.len())));
+        self.body
+            .push_conj(body.map_var(|v| v.shift_existential(self.existentials.len())));
         self.existentials.extend(existentials);
 
         let mut substs = HashMap::new();
@@ -817,12 +816,12 @@ impl<T> UnbindAtoms<T> {
             substs.insert(v, ev);
         }
 
-        let mut formula = self.formula.map_var(|v| match v {
+        let mut body = self.body.map_var(|v| match v {
             rty::RefinedTypeVar::Value => rty::RefinedTypeVar::Value,
             rty::RefinedTypeVar::Free(v) => rty::RefinedTypeVar::Existential(substs[&v]),
             rty::RefinedTypeVar::Existential(ev) => rty::RefinedTypeVar::Existential(ev),
         });
-        formula.push_conj(
+        body.push_conj(
             self.target_equations
                 .into_iter()
                 .map(|(t, term)| {
@@ -839,7 +838,7 @@ impl<T> UnbindAtoms<T> {
                 .collect::<Vec<_>>(),
         );
 
-        let refinement = rty::Refinement::with_formula(self.existentials, formula);
+        let refinement = rty::Refinement::new(self.existentials, body);
         // TODO: polymorphic datatypes: template needed?
         rty::RefinedType::new(src_ty.assert_closed().vacuous(), refinement)
     }
@@ -892,11 +891,8 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
 
         for (idx, param) in expected_params.iter_enumerated() {
-            let rty::Refinement {
-                existentials,
-                formula,
-            } = param.refinement.clone();
-            assumption.formula.push_conj(formula.subst_var(|v| match v {
+            let rty::Refinement { existentials, body } = param.refinement.clone();
+            assumption.formula.push_conj(body.subst_var(|v| match v {
                 rty::RefinedTypeVar::Value => param_terms[&idx].clone(),
                 rty::RefinedTypeVar::Free(v) => param_terms[&v].clone(),
                 rty::RefinedTypeVar::Existential(ev) => chc::Term::var(PlaceTypeVar::Existential(

--- a/src/chc/format_context.rs
+++ b/src/chc/format_context.rs
@@ -197,10 +197,7 @@ fn collect_sorts(system: &chc::System) -> BTreeSet<chc::Sort> {
     for clause in &system.clauses {
         sorts.extend(clause.vars.clone());
         atom_sorts(clause, &clause.head, &mut sorts);
-        for a in &clause.body_atoms {
-            atom_sorts(clause, a, &mut sorts);
-        }
-        for a in clause.body_formula.atoms() {
+        for a in clause.body.iter_atoms() {
             atom_sorts(clause, a, &mut sorts);
         }
     }

--- a/src/chc/unbox.rs
+++ b/src/chc/unbox.rs
@@ -53,23 +53,27 @@ fn unbox_formula(formula: Formula) -> Formula {
     }
 }
 
+fn unbox_body(body: Body) -> Body {
+    let Body { atoms, formula } = body;
+    let atoms = atoms.into_iter().map(unbox_atom).collect();
+    let formula = unbox_formula(formula);
+    Body { atoms, formula }
+}
+
 fn unbox_clause(clause: Clause) -> Clause {
     let Clause {
         vars,
         head,
-        body_atoms,
-        body_formula,
+        body,
         debug_info,
     } = clause;
     let vars = vars.into_iter().map(unbox_sort).collect();
     let head = unbox_atom(head);
-    let body_atoms = body_atoms.into_iter().map(unbox_atom).collect();
-    let body_formula = unbox_formula(body_formula);
+    let body = unbox_body(body);
     Clause {
         vars,
         head,
-        body_atoms,
-        body_formula,
+        body,
         debug_info,
     }
 }

--- a/src/refine.rs
+++ b/src/refine.rs
@@ -5,7 +5,7 @@ mod basic_block;
 pub use basic_block::BasicBlockType;
 
 mod env;
-pub use env::{Env, PlaceType, PlaceTypeVar, TempVarIdx, UnboundAssumption, Var};
+pub use env::{Assumption, Env, PlaceType, PlaceTypeVar, TempVarIdx, Var};
 
 use crate::chc::DatatypeSymbol;
 use rustc_middle::ty as mir_ty;

--- a/src/refine/env.rs
+++ b/src/refine/env.rs
@@ -9,7 +9,7 @@ use rustc_target::abi::{FieldIdx, VariantIdx};
 use crate::chc;
 use crate::pretty::PrettyDisplayExt as _;
 use crate::refine;
-use crate::rty;
+use crate::rty::{self, ShiftExistential as _};
 
 rustc_index::newtype_index! {
     #[orderable]
@@ -183,6 +183,15 @@ impl From<PlaceTypeVar> for rty::RefinedTypeVar<Var> {
     }
 }
 
+impl rty::ShiftExistential for PlaceTypeVar {
+    fn shift_existential(self, amount: usize) -> Self {
+        match self {
+            PlaceTypeVar::Var(v) => PlaceTypeVar::Var(v),
+            PlaceTypeVar::Existential(ev) => PlaceTypeVar::Existential(ev + amount),
+        }
+    }
+}
+
 impl std::fmt::Debug for PlaceTypeVar {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -209,13 +218,6 @@ impl PlaceTypeVar {
         match self {
             PlaceTypeVar::Var(v) => Some(v),
             _ => None,
-        }
-    }
-
-    pub fn shift_existential(self, amount: usize) -> Self {
-        match self {
-            PlaceTypeVar::Var(v) => PlaceTypeVar::Var(v),
-            PlaceTypeVar::Existential(ev) => PlaceTypeVar::Existential(ev + amount),
         }
     }
 }
@@ -300,7 +302,7 @@ impl PlaceType {
         }
     }
 
-    pub fn into_assumption<F>(self, term_to_atom: F) -> UnboundAssumption
+    pub fn into_assumption<F>(self, term_to_atom: F) -> Assumption
     where
         F: FnOnce(chc::Term<PlaceTypeVar>) -> chc::Atom<PlaceTypeVar>,
     {
@@ -311,10 +313,7 @@ impl PlaceType {
             mut formula,
         } = self;
         formula.push_conj(term_to_atom(term));
-        UnboundAssumption {
-            existentials,
-            formula,
-        }
+        Assumption::new(existentials, formula)
     }
 
     pub fn deref(self) -> PlaceType {
@@ -477,7 +476,7 @@ impl PlaceType {
         }
     }
 
-    pub fn merge_into_assumption<F>(self, other: PlaceType, f: F) -> UnboundAssumption
+    pub fn merge_into_assumption<F>(self, other: PlaceType, f: F) -> Assumption
     where
         F: FnOnce(chc::Term<PlaceTypeVar>, chc::Term<PlaceTypeVar>) -> chc::Atom<PlaceTypeVar>,
     {
@@ -500,10 +499,7 @@ impl PlaceType {
         formula.push_conj(formula2.map_var(|v| v.shift_existential(existentials.len())));
         formula.push_conj(atom);
         existentials.extend(evs2);
-        UnboundAssumption {
-            existentials,
-            formula,
-        }
+        Assumption::new(existentials, formula)
     }
 
     pub fn merge<F>(self, other: PlaceType, f: F) -> PlaceType
@@ -655,101 +651,14 @@ impl PlaceType {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct UnboundAssumption {
-    pub existentials: IndexVec<rty::ExistentialVarIdx, chc::Sort>,
-    pub formula: chc::Body<PlaceTypeVar>,
-}
-
-impl From<chc::Atom<Var>> for UnboundAssumption {
-    fn from(atom: chc::Atom<Var>) -> Self {
-        let existentials = IndexVec::new();
-        let formula = chc::Body::new(vec![atom.map_var(Into::into)], Default::default());
-        UnboundAssumption {
-            existentials,
-            formula,
-        }
-    }
-}
-
-impl Extend<UnboundAssumption> for UnboundAssumption {
-    fn extend<T>(&mut self, iter: T)
-    where
-        T: IntoIterator<Item = UnboundAssumption>,
-    {
-        for assumption in iter {
-            self.formula.push_conj(
-                assumption
-                    .formula
-                    .map_var(|v| v.shift_existential(self.existentials.len())),
-            );
-            self.existentials.extend(assumption.existentials);
-        }
-        self.formula.simplify();
-    }
-}
-
-impl FromIterator<UnboundAssumption> for UnboundAssumption {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = UnboundAssumption>,
-    {
-        let mut result = UnboundAssumption::default();
-        result.extend(iter);
-        result
-    }
-}
-
-impl<'a, 'b, D> Pretty<'a, D, termcolor::ColorSpec> for &'b UnboundAssumption
-where
-    D: pretty::DocAllocator<'a, termcolor::ColorSpec>,
-    D::Doc: Clone,
-{
-    fn pretty(self, allocator: &'a D) -> pretty::DocBuilder<'a, D, termcolor::ColorSpec> {
-        let existentials = allocator
-            .intersperse(
-                self.existentials
-                    .iter_enumerated()
-                    .map(|(v, s)| v.pretty(allocator).append(allocator.text(":")).append(s)),
-                allocator.text(",").append(allocator.line()),
-            )
-            .group();
-        let formula = self.formula.pretty(allocator);
-        if self.existentials.is_empty() {
-            formula
-        } else {
-            allocator
-                .text("∃")
-                .append(existentials.nest(2))
-                .append(allocator.text("."))
-                .append(allocator.line().append(formula).nest(2))
-                .group()
-        }
-    }
-}
-
-impl UnboundAssumption {
-    pub fn new(
-        existentials: IndexVec<rty::ExistentialVarIdx, chc::Sort>,
-        formula: chc::Body<PlaceTypeVar>,
-    ) -> Self {
-        UnboundAssumption {
-            existentials,
-            formula,
-        }
-    }
-
-    pub fn is_top(&self) -> bool {
-        self.formula.is_top()
-    }
-}
+pub type Assumption = rty::Formula<PlaceTypeVar>;
 
 #[derive(Debug, Clone)]
 pub struct Env {
     locals: BTreeMap<Local, rty::RefinedType<Var>>,
     flow_locals: BTreeMap<Local, FlowBinding>,
     temp_vars: IndexVec<TempVarIdx, TempVarBinding>,
-    unbound_assumptions: Vec<UnboundAssumption>,
+    assumptions: Vec<Assumption>,
 
     enum_defs: HashMap<chc::DatatypeSymbol, rty::EnumDatatypeDef>,
 
@@ -781,13 +690,13 @@ impl rty::ClauseScope for Env {
             }
             builder.add_body(formula);
         }
-        for assumption in &self.unbound_assumptions {
+        for assumption in &self.assumptions {
             let mut evs = HashMap::new();
             for (ev, sort) in assumption.existentials.iter_enumerated() {
                 let tv = builder.add_var(sort.clone());
                 evs.insert(ev, tv);
             }
-            let chc::Body { formula, atoms } = assumption.formula.clone().map_var(|v| match v {
+            let chc::Body { formula, atoms } = assumption.body.clone().map_var(|v| match v {
                 PlaceTypeVar::Var(v) => builder.mapped_var(v),
                 PlaceTypeVar::Existential(ev) => evs[&ev],
             });
@@ -816,7 +725,7 @@ impl Env {
             locals: Default::default(),
             flow_locals: Default::default(),
             temp_vars: IndexVec::new(),
-            unbound_assumptions: Vec::new(),
+            assumptions: Vec::new(),
             enum_defs,
             enum_expansion_depth_limit: std::env::var("THRUST_ENUM_EXPANSION_DEPTH_LIMIT")
                 .ok()
@@ -934,10 +843,7 @@ impl Env {
             });
             formula.push_conj(tuple_ty.formula);
             existentials.extend(refinement.existentials);
-            UnboundAssumption {
-                existentials,
-                formula,
-            }
+            Assumption::new(existentials, formula)
         };
         self.assume(assumption);
         let binding = FlowBinding::Tuple(xs.clone());
@@ -982,20 +888,20 @@ impl Env {
 
         let mut existentials = refinement.existentials;
         let value_var_ev = existentials.push(rty::Type::Enum(ty.clone()).to_sort());
-        let mut assumption = UnboundAssumption {
+        let mut assumption = Assumption::new(
             existentials,
-            formula: refinement.body.map_var(|v| match v {
+            refinement.body.map_var(|v| match v {
                 rty::RefinedTypeVar::Value => PlaceTypeVar::Existential(value_var_ev),
                 rty::RefinedTypeVar::Free(v) => PlaceTypeVar::Var(v),
                 rty::RefinedTypeVar::Existential(ev) => PlaceTypeVar::Existential(ev),
             }),
-        };
+        );
         let mut pred_args: Vec<_> = variants
             .iter()
             .flat_map(|v| &v.fields)
             .map(|&x| {
                 let ty = self.var_type(x.into());
-                assumption.formula.push_conj(
+                assumption.body.push_conj(
                     ty.formula
                         .map_var(|v| v.shift_existential(assumption.existentials.len())),
                 );
@@ -1008,7 +914,7 @@ impl Env {
             .collect();
         pred_args.push(chc::Term::var(value_var_ev.into()));
         assumption
-            .formula
+            .body
             .push_conj(chc::Atom::new(matcher_pred.into(), pred_args));
         let discr_var = self
             .temp_vars
@@ -1016,7 +922,7 @@ impl Env {
                 rty::Type::int(),
             )));
         assumption
-            .formula
+            .body
             .push_conj(
                 chc::Term::var(discr_var.into()).equal_to(chc::Term::datatype_discr(
                     def.name.clone(),
@@ -1079,14 +985,14 @@ impl Env {
         tracing::debug!(local = ?local, rty = %rty_disp.display(), place_type = %self.local_type(local).display(), "immut_bind");
     }
 
-    pub fn assume(&mut self, assumption: impl Into<UnboundAssumption>) {
+    pub fn assume(&mut self, assumption: impl Into<Assumption>) {
         let assumption = assumption.into();
         tracing::debug!(assumption = %assumption.display(), "assume");
-        self.unbound_assumptions.push(assumption);
+        self.assumptions.push(assumption);
     }
 
-    pub fn extend_assumptions(&mut self, assumptions: Vec<impl Into<UnboundAssumption>>) {
-        self.unbound_assumptions
+    pub fn extend_assumptions(&mut self, assumptions: Vec<impl Into<Assumption>>) {
+        self.assumptions
             .extend(assumptions.into_iter().map(Into::into));
     }
 
@@ -1343,7 +1249,7 @@ impl Env {
         self.path_type(&place.into())
     }
 
-    fn dropping_assumption(&mut self, path: &Path) -> UnboundAssumption {
+    fn dropping_assumption(&mut self, path: &Path) -> Assumption {
         let ty = self.path_type(path);
         if ty.ty.is_mut() {
             ty.into_assumption(|term| {
@@ -1404,24 +1310,21 @@ impl Env {
                     }
                 };
 
-                let UnboundAssumption {
+                let Assumption {
                     existentials: assumption_existentials,
-                    formula: assumption_formula,
+                    body: assumption_body,
                 } = self.dropping_assumption(&Path::PlaceTy(field_pty));
                 // dropping assumption should not generate any existential
                 assert!(assumption_existentials.is_empty());
-                formula.push_conj(assumption_formula);
+                formula.push_conj(assumption_body);
             }
 
             pred_args.push(term);
             formula.push_conj(chc::Atom::new(matcher_pred.into(), pred_args));
 
-            UnboundAssumption {
-                existentials,
-                formula,
-            }
+            Assumption::new(existentials, formula)
         } else {
-            UnboundAssumption::default()
+            Assumption::default()
         }
     }
 

--- a/src/refine/template.rs
+++ b/src/refine/template.rs
@@ -147,13 +147,10 @@ where
         &mut self,
         refinement: rty::Refinement<rty::FunctionParamIdx>,
     ) -> &mut Self {
-        let rty::Refinement {
-            existentials,
-            formula,
-        } = refinement;
+        let rty::Refinement { existentials, body } = refinement;
         let refinement = rty::Refinement {
             existentials,
-            formula: formula.map_var(|v| match v {
+            body: body.map_var(|v| match v {
                 rty::RefinedTypeVar::Free(idx) if idx.index() == self.param_tys.len() - 1 => {
                     rty::RefinedTypeVar::Value
                 }

--- a/src/rty.rs
+++ b/src/rty.rs
@@ -1009,10 +1009,7 @@ where
 }
 
 impl<V> Formula<V> {
-    pub fn new(
-        existentials: IndexVec<ExistentialVarIdx, chc::Sort>,
-        body: chc::Body<V>,
-    ) -> Self {
+    pub fn new(existentials: IndexVec<ExistentialVarIdx, chc::Sort>, body: chc::Body<V>) -> Self {
         Formula { existentials, body }
     }
 

--- a/src/rty/clause_builder.rs
+++ b/src/rty/clause_builder.rs
@@ -1,6 +1,6 @@
 use crate::chc;
 
-use super::{FormulaWithAtoms, Refinement, Type};
+use super::{Refinement, Type};
 
 pub trait ClauseBuilderExt {
     fn with_value_var<'a, T>(&'a mut self, ty: &Type<T>) -> RefinementClauseBuilder<'a>;
@@ -55,11 +55,11 @@ impl<'a> RefinementClauseBuilder<'a> {
         if let Some(value_var) = self.value_var {
             instantiator.value_var(value_var);
         }
-        let FormulaWithAtoms { atoms, formula } = instantiator.instantiate();
+        let chc::Body { atoms, formula } = instantiator.instantiate();
         for atom in atoms {
             self.builder.add_body(atom);
         }
-        self.builder.add_body_formula(formula);
+        self.builder.add_body(formula);
         self
     }
 
@@ -76,7 +76,7 @@ impl<'a> RefinementClauseBuilder<'a> {
         if let Some(value_var) = self.value_var {
             instantiator.value_var(value_var);
         }
-        let FormulaWithAtoms { atoms, formula } = instantiator.instantiate();
+        let chc::Body { atoms, formula } = instantiator.instantiate();
         let mut cs = atoms
             .into_iter()
             .map(|a| self.builder.head(a))
@@ -84,9 +84,7 @@ impl<'a> RefinementClauseBuilder<'a> {
         if !formula.is_top() {
             cs.push({
                 let mut builder = self.builder.clone();
-                builder
-                    .add_body_formula(formula.not())
-                    .head(chc::Atom::bottom())
+                builder.add_body(formula.not()).head(chc::Atom::bottom())
             });
         }
         cs

--- a/src/rty/params.rs
+++ b/src/rty/params.rs
@@ -84,7 +84,7 @@ impl<T> TypeParamSubst<T> {
         for (idx, mut t1) in other.subst {
             t1.subst_ty_params(self);
             if let Some(t2) = self.subst.remove(&idx) {
-                t1.refinement.extend(t2.refinement);
+                t1.refinement.push_conj(t2.refinement);
             }
             self.subst.insert(idx, t1);
         }


### PR DESCRIPTION
- chc::Body: atoms with chc::Formula (formerly rty::FormulaWithAtoms)
- rty::Formula: chc::Body with existentials
- UnboundAssumption -> Assumption = rty::Formula<PlaceTypeVar>
- Refinement = rty::Formula<RefinedTypeVar>

It may be confusing that chc::Formula and rty::Formula have the same name but have different roles; however, I couldn't come up with a better name.