### PR TITLE
Enable to parse enum constructors in annotations

### DIFF
--- a/tests/ui/fail/annot_enum_simple.rs
+++ b/tests/ui/fail/annot_enum_simple.rs
@@ -1,0 +1,20 @@
+//@error-in-other-file: Unsat
+
+pub enum X {
+    A(i64),
+    B(bool),
+}
+
+#[thrust::requires(x == X::A(1))]
+#[thrust::ensures(true)]
+fn test(x: X) {
+    if let X::A(i) = x {
+        assert!(i == 2);
+    } else {
+        loop {}
+    }
+}
+
+fn main() {
+    test(X::A(1));
+}

--- a/tests/ui/pass/annot_enum_simple.rs
+++ b/tests/ui/pass/annot_enum_simple.rs
@@ -1,0 +1,20 @@
+//@check-pass
+
+pub enum X {
+    A(i64),
+    B(bool),
+}
+
+#[thrust::requires(x == X::A(1))]
+#[thrust::ensures(true)]
+fn test(x: X) {
+    if let X::A(i) = x {
+        assert!(i == 1);
+    } else {
+        loop {}
+    }
+}
+
+fn main() {
+    test(X::A(1));
+}


### PR DESCRIPTION
supports only simple cases in ad-hoc way.

I plan to re-implement annotations by lifting annotation expressions into Rust functions using macros. This will allow rustc to parse them into HIR, effectively delegating path resolution to the compiler.