### PR TITLE
Allow non-return ZST places to appear without proceding defs in BB

### DIFF
--- a/tests/ui/fail/closure_field_1.rs
+++ b/tests/ui/fail/closure_field_1.rs
@@ -1,0 +1,14 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+struct S<F> {
+    f: F,
+}
+
+fn main() {
+    let s = S {
+        f: |x: i32| x + 1,
+    };
+    let x = (s.f)(1);
+    assert!(x == 1);
+}

--- a/tests/ui/pass/closure_field_1.rs
+++ b/tests/ui/pass/closure_field_1.rs
@@ -1,0 +1,14 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+struct S<F> {
+    f: F,
+}
+
+fn main() {
+    let s = S {
+        f: |x: i32| x + 1,
+    };
+    let x = (s.f)(1);
+    assert!(x == 2);
+}


### PR DESCRIPTION
fix #38 

Closures without upvars are treated as a ZST. Given the MIR below, `_1` is a ZST and is used without proceeding defs in bb0.

```rust
// MIR for `main` after runtime-optimized

fn main() -> () {
    let mut _0: ();
    let _1: S<{closure@closure_field.rs:7:12: 7:20}>;
    let mut _3: &{closure@closure_field.rs:7:12: 7:20};
    let mut _4: (i32,);
    let mut _5: !;
    scope 1 {
        debug s => const S::<{closure@closure_field.rs:7:12: 7:20}> {{ f: ZeroSized: {closure@closure_field.rs:7:12: 7:20} }};
        let _2: i32;
        scope 2 {
            debug x => _2;
        }
    }

    bb0: {
        _3 = &(_1.0: {closure@closure_field.rs:7:12: 7:20});
        _4 = (const 1_i32,);
        _2 = <{closure@closure_field.rs:7:12: 7:20} as Fn<(i32,)>>::call(move _3, move _4) -> [return: bb1, unwind continue];
    }

    bb1: {
        switchInt(_2) -> [2: bb2, otherwise: bb3];
    }

    bb2: {
        return;
    }

    bb3: {
        _5 = core::panicking::panic(const "assertion failed: x == 2") -> unwind continue;
    }
}
```

Because `_1` has no preceding definitions, bb0 has the type `(_0: (), _1: (own (), )) → ()`, where _1 is left as a live local. However, since `_1` is not a function parameter in this case, local_def::Analyzer::elaborate_unused_args needs to ignore `_1` within the arguments of bb0.

```
DEBUG crate:def: thrust::analyze::local_def: assert_entry before expected=({ () |  p0 }) → { () |  p1 } entry=(_0: (), _1: { (own (), ) |  p10 }) → { () |  p11 } krate=closure_field def=main
DEBUG crate:def: thrust::analyze::local_def: assert_entry after expected=({ () |  p0 }) → { () |  p1 } entry=({ (own (), ) |  p10 }) → { () |  p11 } krate=closure_field def=main
DEBUG crate:def: thrust::rty::subtyping: relate_sub_closed_type got=({ (own (), ) |  p10 }) → { () |  p11 } expected=({ () |  p0 }) → { () |  p1 } krate=closure_field def=main
DEBUG crate:def: thrust::rty::subtyping: sub_type got=({ (own (), ) |  p10 }) → { () |  p11 } expected=({ () |  p0 }) → { () |  p1 } krate=closure_field def=main
DEBUG crate:def: thrust::rty::subtyping: sub_refined_type got={ () |  p0 } expected={ (own (), ) |  p10 } krate=closure_field def=main
DEBUG crate:def: thrust::rty::subtyping: sub_type got=() expected=(own (),
) krate=closure_field def=main
```