### PR TITLE
Enable to use thrust_macros::{ensures,requires} for trait method annotations

### DIFF
--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -482,7 +482,33 @@ impl<'tcx> AnnotFnTranslator<'tcx> {
                             .next()
                             .is_some()
                         {
-                            let pred = refine::user_defined_pred(self.tcx, def_id);
+                            let param_env = self
+                                .tcx
+                                .param_env(self.local_def_id)
+                                .with_reveal_all_normalized(self.tcx);
+                            let generic_args = self.typeck.node_args(func_expr.hir_id);
+                            tracing::debug!(
+                                lhs = ?def_id,
+                                lhs_generic_args = ?generic_args,
+                                outer = ?self.local_def_id,
+                                outer_generic_args = ?self.generic_args,
+                                "resolving predicate call in formula"
+                            );
+                            let generic_args = mir_ty::EarlyBinder::bind(generic_args)
+                                .instantiate(self.tcx, self.generic_args);
+                            let instance = mir_ty::Instance::resolve(
+                                self.tcx,
+                                param_env,
+                                def_id,
+                                generic_args,
+                            )
+                            .unwrap();
+                            let pred_def_id = if let Some(instance) = instance {
+                                instance.def_id()
+                            } else {
+                                def_id
+                            };
+                            let pred = refine::user_defined_pred(self.tcx, pred_def_id);
                             let arg_terms = args.iter().map(|e| self.to_term(e)).collect();
                             let atom = chc::Atom::new(pred.into(), arg_terms);
                             return FormulaOrTerm::Formula(chc::Formula::Atom(atom));

--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -420,12 +420,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                 _ty,
             ) => {
                 let func_ty = match operand.const_fn_def() {
-                    Some((def_id, args)) => self
-                        .ctx
-                        .def_ty_with_args(def_id, args)
-                        .expect("unknown def")
-                        .ty
-                        .clone(),
+                    Some((def_id, args)) => self.fn_def_ty(def_id, args),
                     _ => unimplemented!(),
                 };
                 PlaceType::with_ty_and_term(func_ty.vacuous(), chc::Term::null())
@@ -573,44 +568,68 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         });
     }
 
+    fn resolve_fn_def(
+        &self,
+        def_id: DefId,
+        args: mir_ty::GenericArgsRef<'tcx>,
+    ) -> (DefId, mir_ty::GenericArgsRef<'tcx>) {
+        if self.ctx.is_fn_trait_method(def_id) {
+            // When calling a closure via `Fn`/`FnMut`/`FnOnce` trait,
+            // we simply replace the def_id with the closure's function def_id.
+            // This skips shims, and makes self arguments mismatch. visitor::RustCallVisitor
+            // adjusts the arguments accordingly.
+            let mir_ty::TyKind::Closure(closure_def_id, _) = args.type_at(0).kind() else {
+                panic!("expected closure arg for fn trait");
+            };
+            tracing::debug!(?closure_def_id, "closure instance");
+            (*closure_def_id, args)
+        } else {
+            let param_env = self
+                .tcx
+                .param_env(self.local_def_id)
+                .with_reveal_all_normalized(self.tcx);
+            let instance = mir_ty::Instance::resolve(self.tcx, param_env, def_id, args).unwrap();
+            if let Some(instance) = instance {
+                (instance.def_id(), instance.args)
+            } else {
+                (def_id, args)
+            }
+        }
+    }
+
+    fn fn_def_ty(
+        &mut self,
+        def_id: DefId,
+        args: mir_ty::GenericArgsRef<'tcx>,
+    ) -> rty::Type<rty::Closed> {
+        if let Some(def_ty) = self.ctx.def_ty_with_args(def_id, args) {
+            return def_ty.ty;
+        }
+
+        let (resolved_def_id, resolved_args) = self.resolve_fn_def(def_id, args);
+        if resolved_def_id == def_id {
+            panic!(
+                "unknown def (and not resolved): {:?}, args: {:?}",
+                def_id, args
+            );
+        }
+        tracing::info!(?def_id, ?resolved_def_id, ?resolved_args, "resolved");
+        let Some(def_ty) = self.ctx.def_ty_with_args(resolved_def_id, resolved_args) else {
+            panic!(
+                "unknown def (resolved): {:?}, args: {:?}",
+                resolved_def_id, resolved_args
+            );
+        };
+        def_ty.ty
+    }
+
     fn type_call<I>(&mut self, func: Operand<'tcx>, args: I, expected_ret: &rty::RefinedType<Var>)
     where
         I: IntoIterator<Item = Operand<'tcx>>,
     {
         // TODO: handle const_fn_def on Env side
         let func_ty = if let Some((def_id, args)) = func.const_fn_def() {
-            let (resolved_def_id, resolved_args) = if self.ctx.is_fn_trait_method(def_id) {
-                // When calling a closure via `Fn`/`FnMut`/`FnOnce` trait,
-                // we simply replace the def_id with the closure's function def_id.
-                // This skips shims, and makes self arguments mismatch. visitor::RustCallVisitor
-                // adjusts the arguments accordingly.
-                let mir_ty::TyKind::Closure(closure_def_id, _) = args.type_at(0).kind() else {
-                    panic!("expected closure arg for fn trait");
-                };
-                tracing::debug!(?closure_def_id, "closure instance");
-                (*closure_def_id, args)
-            } else {
-                let param_env = self
-                    .tcx
-                    .param_env(self.local_def_id)
-                    .with_reveal_all_normalized(self.tcx);
-                let instance =
-                    mir_ty::Instance::resolve(self.tcx, param_env, def_id, args).unwrap();
-                if let Some(instance) = instance {
-                    (instance.def_id(), instance.args)
-                } else {
-                    (def_id, args)
-                }
-            };
-            if def_id != resolved_def_id {
-                tracing::info!(?def_id, ?resolved_def_id, ?resolved_args, "resolved");
-            }
-
-            self.ctx
-                .def_ty_with_args(resolved_def_id, resolved_args)
-                .expect("unknown def")
-                .ty
-                .vacuous()
+            self.fn_def_ty(def_id, args).vacuous()
         } else {
             self.operand_type(func.clone()).ty
         };

--- a/src/analyze/crate_.rs
+++ b/src/analyze/crate_.rs
@@ -89,7 +89,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
 
         if analyzer.is_annotated_as_predicate() {
-            analyzer.analyze_predicate_definition(local_def_id);
+            analyzer.analyze_predicate_definition();
             self.skip_analysis.insert(local_def_id);
             return;
         }

--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -276,7 +276,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             || (all_params_annotated && has_ret)
     }
 
-    pub fn trait_item_id(&self) -> Option<LocalDefId> {
+    pub fn local_trait_item_id(&self) -> Option<LocalDefId> {
         let impl_item_assoc = self
             .tcx
             .opt_associated_item(self.local_def_id.to_def_id())?;
@@ -284,9 +284,33 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             .trait_item_def_id
             .and_then(|id| id.as_local())?;
 
+        if trait_item_id == self.local_def_id {
+            return None;
+        }
+
         Some(trait_item_id)
     }
 
+    pub fn trait_item_ty(&mut self) -> Option<rty::RefinedType> {
+        let impl_did = self.tcx.parent(self.local_def_id.to_def_id());
+
+        if self.tcx.def_kind(impl_did) != (rustc_hir::def::DefKind::Impl { of_trait: true }) {
+            return None;
+        }
+
+        let trait_ref = self.tcx.impl_trait_ref(impl_did)?.instantiate_identity();
+        let trait_item_did = self
+            .tcx
+            .associated_item(self.local_def_id.to_def_id())
+            .trait_item_def_id
+            .unwrap();
+        self.ctx.def_ty_with_args(trait_item_did, trait_ref.args)
+    }
+
+    // Note that we do not expect predicate variables to be generated here
+    // when type params are still present in the type. Callers should ensure either
+    // - type params are fully instantiated, or
+    // - the function is fully annotated
     pub fn expected_ty(&mut self) -> rty::RefinedType {
         let sig = self
             .ctx
@@ -324,7 +348,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             self.generic_args,
         );
 
-        if let Some(trait_item_id) = self.trait_item_id() {
+        if let Some(trait_item_id) = self.local_trait_item_id() {
             tracing::info!("trait item found: {:?}", trait_item_id);
             let trait_require_annot = self.ctx.extract_require_annot(
                 trait_item_id,
@@ -364,6 +388,9 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         assert!(require_annot.is_none() || param_annots.is_empty());
         assert!(ensure_annot.is_none() || ret_annot.is_none());
 
+        let trait_item_ty = self.trait_item_ty();
+        let is_fully_annotated = self.is_fully_annotated();
+
         let mut builder = self.type_builder.for_function_template(&mut self.ctx, sig);
         if let Some(AnnotFormula::Formula(require)) = require_annot {
             let formula = require.map_var(|idx| {
@@ -387,11 +414,13 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             builder.ret_rty(ret_rty);
         }
 
-        // Note that we do not expect predicate variables to be generated here
-        // when type params are still present in the type. Callers should ensure either
-        // - type params are fully instantiated, or
-        // - the function is fully annotated
-        rty::RefinedType::unrefined(builder.build().into())
+        if is_fully_annotated {
+            rty::RefinedType::unrefined(builder.build().into())
+        } else if let Some(trait_item_ty) = trait_item_ty {
+            trait_item_ty
+        } else {
+            rty::RefinedType::unrefined(builder.build().into())
+        }
     }
 
     /// Extract the target DefId from `#[thrust::extern_spec_fn]` function.

--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -115,22 +115,33 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         Some(self_ty)
     }
 
-    pub fn analyze_predicate_definition(&self, local_def_id: LocalDefId) {
-        // predicate's name
-        // TODO: simply use refine::user_defined_pred for all functions
-        //       after we dropped old annotation parser impl
-        let impl_type = self.impl_type();
-        let pred_item_name = self.tcx.item_name(local_def_id.to_def_id()).to_string();
-        let pred = match impl_type {
-            Some(t) => chc::UserDefinedPred::new(t.to_string() + "_" + &pred_item_name),
-            None => refine::user_defined_pred(self.tcx, local_def_id.to_def_id()),
-        };
+    pub fn analyze_predicate_definition(&self) {
+        self.define_as_predicate(refine::user_defined_pred(
+            self.tcx,
+            self.local_def_id.to_def_id(),
+        ));
 
+        // For thrust::{requires,ensures} annotations which does not know DefId of the predicate
+        // during parsing, we also define a predicate with a name based on the self type name
+        //
+        // TODO: remove this after we dropped old annotation parser impl
+        //       (then move this to crate_::Analyzer)
+        let pred_item_name = self
+            .tcx
+            .item_name(self.local_def_id.to_def_id())
+            .to_string();
+        if let Some(self_ty) = self.impl_type() {
+            let name = chc::UserDefinedPred::new(self_ty.to_string() + "_" + &pred_item_name);
+            self.define_as_predicate(name);
+        }
+    }
+
+    fn define_as_predicate(&self, pred: chc::UserDefinedPred) {
         // function's body
         use rustc_hir::{Block, Expr, ExprKind};
 
         let hir_map = self.tcx.hir();
-        let body_id = hir_map.maybe_body_owned_by(local_def_id).unwrap();
+        let body_id = hir_map.maybe_body_owned_by(self.local_def_id).unwrap();
         let hir_body = hir_map.body(body_id);
 
         let predicate_body = match hir_body.value {
@@ -147,11 +158,11 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         // names and sorts of arguments
         let arg_names = self
             .tcx
-            .fn_arg_names(local_def_id.to_def_id())
+            .fn_arg_names(self.local_def_id.to_def_id())
             .iter()
             .map(|ident| ident.to_string());
 
-        let sig = self.ctx.fn_sig(local_def_id.to_def_id());
+        let sig = self.ctx.fn_sig(self.local_def_id.to_def_id());
         let arg_sorts = sig
             .inputs()
             .iter()

--- a/std.rs
+++ b/std.rs
@@ -63,7 +63,7 @@ mod thrust_models {
         }
 
         #[thrust::def::mut_model]
-        pub struct Mut<T>(PhantomData<T>);
+        pub struct Mut<T: ?Sized>(PhantomData<T>);
 
         impl<T> Mut<T> {
             #[allow(dead_code)]
@@ -100,7 +100,7 @@ mod thrust_models {
         }
 
         #[thrust::def::box_model]
-        pub struct Box<T>(PhantomData<T>);
+        pub struct Box<T: ?Sized>(PhantomData<T>);
 
         impl<T> Box<T> {
             #[allow(dead_code)]
@@ -128,7 +128,7 @@ mod thrust_models {
         }
 
         #[thrust::def::array_model]
-        pub struct Array<I, T>(PhantomData<I>, PhantomData<T>);
+        pub struct Array<I: ?Sized, T: ?Sized>(PhantomData<I>, PhantomData<T>);
 
         impl<I, T, U> PartialEq<U> for Array<I, T> where U: super::Model<Ty = Self> {
             #[thrust::ignored]
@@ -156,9 +156,9 @@ mod thrust_models {
         }
 
         #[thrust::def::closure_model]
-        pub struct Closure<T>(PhantomData<T>);
+        pub struct Closure<T: ?Sized>(PhantomData<T>);
 
-        pub struct Vec<T>(pub Array<Int, T>, pub Int);
+        pub struct Vec<T: ?Sized>(pub Array<Int, T>, pub Int);
 
         impl<T, U> PartialEq<U> for Vec<T> where U: super::Model<Ty = Self> {
             #[thrust::ignored]
@@ -200,7 +200,7 @@ mod thrust_models {
         type Ty = bool;
     }
 
-    impl<T> Model for model::Closure<T> {
+    impl<T: ?Sized> Model for model::Closure<T> {
         type Ty = model::Closure<T>;
     }
 
@@ -224,27 +224,27 @@ mod thrust_models {
     impl_tuple_model!(T0, T1, T2, T3, T4, T5, T6, T7, T8);
     impl_tuple_model!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9);
 
-    impl<'a, T> Model for &'a mut T where T: Model {
+    impl<'a, T: ?Sized> Model for &'a mut T where T: Model {
         type Ty = model::Mut<<T as Model>::Ty>;
     }
 
-    impl<T> Model for model::Mut<T> {
+    impl<T: ?Sized> Model for model::Mut<T> {
         type Ty = model::Mut<T>;
     }
 
-    impl<'a, T> Model for &'a T where T: Model {
+    impl<'a, T: ?Sized> Model for &'a T where T: Model {
         type Ty = &'a <T as Model>::Ty;
     }
 
-    impl<T> Model for Box<T> where T: Model {
+    impl<T: ?Sized> Model for Box<T> where T: Model {
         type Ty = model::Box<<T as Model>::Ty>;
     }
 
-    impl<T> Model for model::Box<T> {
+    impl<T: ?Sized> Model for model::Box<T> {
         type Ty = model::Box<T>;
     }
 
-    impl<I, T> Model for model::Array<I, T> {
+    impl<I: ?Sized, T: ?Sized> Model for model::Array<I, T> {
         type Ty = model::Array<I, T>;
     }
 
@@ -252,7 +252,7 @@ mod thrust_models {
         type Ty = model::Vec<<T as Model>::Ty>;
     }
 
-    impl<T> Model for model::Vec<T> {
+    impl<T: ?Sized> Model for model::Vec<T> {
         type Ty = model::Vec<T>;
     }
 

--- a/tests/ui/fail/annot_preds_trait.rs
+++ b/tests/ui/fail/annot_preds_trait.rs
@@ -2,6 +2,7 @@
 //@compile-flags: -Adead_code -C debug-assertions=off
 
 // A is represented as Tuple<Int> in SMT-LIB2 format.
+#[derive(PartialEq)]
 struct A {
     x: i64,
 }
@@ -10,25 +11,27 @@ impl thrust_models::Model for A {
     type Ty = Self;
 }
 
+#[thrust_macros::context]
 trait Double {
     // Support annotations in trait definitions
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool;
 
     // This annotations are applied to all implementors of the `Double` trait.
-    #[thrust::requires(true)]
-    #[thrust::ensures(Self::is_double(*self, ^self))]
+    #[thrust_macros::requires(true)]
+    #[thrust_macros::ensures(Self::is_double(*self, !self))]
     fn double(&mut self);
 }
 
+#[thrust_macros::context]
 impl Double for A {
     // Write concrete definitions for predicates in `impl` blocks
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
         // (tuple_proj<Int>.0 self) is equivalent to self.x
         // self.x * 3 == doubled.x (this isn't actually doubled!) is written as following:
         "(=
-            (* (tuple_proj<Int>.0 self) 3)
+            (* (tuple_proj<Int>.0 self_) 3)
             (tuple_proj<Int>.0 doubled)
         )"; true // This definition does not comply with annotations in trait!
     }

--- a/tests/ui/fail/annot_preds_trait_multi.rs
+++ b/tests/ui/fail/annot_preds_trait_multi.rs
@@ -1,14 +1,15 @@
 //@error-in-other-file: Unsat
 //@compile-flags: -Adead_code -C debug-assertions=off
 
+#[thrust_macros::context]
 trait Double {
     // Support annotations in trait definitions
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool;
 
     // This annotations are applied to all implementors of the `Double` trait.
-    #[thrust::requires(true)]
-    #[thrust::ensures(Self::is_double(*self, ^self))]
+    #[thrust_macros::requires(true)]
+    #[thrust_macros::ensures(Self::is_double(*self, !self))]
     fn double(&mut self);
 }
 
@@ -21,12 +22,13 @@ impl thrust_models::Model for A {
     type Ty = Self;
 }
 
+#[thrust_macros::context]
 impl Double for A {
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
         // self.x * 2 == doubled.x
         "(=
-            (* (tuple_proj<Int>.0 self) 2)
+            (* (tuple_proj<Int>.0 self_) 2)
             (tuple_proj<Int>.0 doubled)
         )"; true
     }
@@ -46,17 +48,18 @@ impl thrust_models::Model for B {
     type Ty = Self;
 }
 
+#[thrust_macros::context]
 impl Double for B {
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
         // self.x * 3 == doubled.x && self.y * 2 == doubled.y (this isn't actually doubled!)
         "(and
             (=
-                (* (tuple_proj<Int-Int>.0 self) 3)
+                (* (tuple_proj<Int-Int>.0 self_) 3)
                 (tuple_proj<Int-Int>.0 doubled)
             )
             (=
-                (* (tuple_proj<Int-Int>.1 self) 2)
+                (* (tuple_proj<Int-Int>.1 self_) 2)
                 (tuple_proj<Int-Int>.1 doubled)
             )
         )"; true // This definition does not comply with annotations in trait!

--- a/tests/ui/fail/iterators/annot_range_loop.rs
+++ b/tests/ui/fail/iterators/annot_range_loop.rs
@@ -2,19 +2,20 @@
 //@compile-flags: -C debug-assertions=off
 //@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper THRUST_SOLVER_TIMEOUT_SECS=60
 
+#[thrust_macros::context]
 trait Iterator {
     type Item;
 
-    #[thrust::requires(true)]
-    #[thrust::ensures(
-        (Self::completed(*self) || (exists i:int. (result == std::option::Option::<int>::Some(i)) && Self::step(*self, i, ^self)))
-        && (!Self::completed(*self) || (result == std::option::Option::<int>::None() && *self == ^self))
+    #[thrust_macros::ensures(
+        Self::completed(*self)
+        || thrust_models::exists(|i| (result == Some(i)) && Self::step(*self, i, !self))
     )]
+    #[thrust_macros::ensures(!Self::completed(*self) || (result == None && *self == !self))]
     fn next(&mut self) -> Option<Self::Item>;
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn completed(self) -> bool;
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn step(self, item: Self::Item, dist: Self) -> bool;
 }
 
@@ -27,6 +28,7 @@ impl thrust_models::Model for Range {
     type Ty = Range;
 }
 
+#[thrust_macros::context]
 impl Iterator for Range {
     type Item = i64;
 
@@ -40,25 +42,25 @@ impl Iterator for Range {
         }
     }
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn completed(self) -> bool {
         // (tuple_proj<Int-Int>.0 self) is equivalent to self.start
         // !(self.start < self.end) is written as following:
         "(not (<
-            (tuple_proj<Int-Int>.0 self)
-            (tuple_proj<Int-Int>.1 self)
+            (tuple_proj<Int-Int>.0 self_)
+            (tuple_proj<Int-Int>.1 self_)
         ))";
         true
     }
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn step(self, item: Self::Item, dist: Self) -> bool {
         // self.end == dist.end && self.start == item && self.start + 1 == dist.start
         // is written as following:
         "(and
-            (= (tuple_proj<Int-Int>.1 self) (tuple_proj<Int-Int>.1 dist))
-            (= (tuple_proj<Int-Int>.0 self) item)
-            (= (+ (tuple_proj<Int-Int>.0 self) 1) (tuple_proj<Int-Int>.0 dist))
+            (= (tuple_proj<Int-Int>.1 self_) (tuple_proj<Int-Int>.1 dist))
+            (= (tuple_proj<Int-Int>.0 self_) item)
+            (= (+ (tuple_proj<Int-Int>.0 self_) 1) (tuple_proj<Int-Int>.0 dist))
         )";
         true
     }

--- a/tests/ui/fail/iterators/annot_range_next.rs
+++ b/tests/ui/fail/iterators/annot_range_next.rs
@@ -2,19 +2,20 @@
 //@compile-flags: -C debug-assertions=off
 //@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
 
+#[thrust_macros::context]
 trait Iterator {
     type Item;
 
-    #[thrust::requires(true)]
-    #[thrust::ensures(
-        (Self::completed(*self) || (exists i:int. (result == std::option::Option::<int>::Some(i)) && Self::step(*self, i, ^self)))
-        && (!Self::completed(*self) || (result == std::option::Option::<int>::None() && *self == ^self))
+    #[thrust_macros::ensures(
+        Self::completed(*self)
+        || thrust_models::exists(|i| (result == Some(i)) && Self::step(*self, i, !self))
     )]
+    #[thrust_macros::ensures(!Self::completed(*self) || (result == None && *self == !self))]
     fn next(&mut self) -> Option<Self::Item>;
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn completed(self) -> bool;
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn step(self, item: Self::Item, dist: Self) -> bool;
 }
 
@@ -27,6 +28,7 @@ impl thrust_models::Model for Range {
     type Ty = Range;
 }
 
+#[thrust_macros::context]
 impl Iterator for Range {
     type Item = i64;
 
@@ -40,25 +42,25 @@ impl Iterator for Range {
         }
     }
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn completed(self) -> bool {
         // (tuple_proj<Int-Int>.0 self) is equivalent to self.start
         // !(self.start < self.end) is written as following:
         "(not (<
-            (tuple_proj<Int-Int>.0 self)
-            (tuple_proj<Int-Int>.1 self)
+            (tuple_proj<Int-Int>.0 self_)
+            (tuple_proj<Int-Int>.1 self_)
         ))";
         true
     }
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn step(self, item: Self::Item, dist: Self) -> bool {
         // self.end == dist.end && self.start == item && self.start + 1 == dist.start
         // is written as following:
         "(and
-            (= (tuple_proj<Int-Int>.1 self) (tuple_proj<Int-Int>.1 dist))
-            (= (tuple_proj<Int-Int>.0 self) item)
-            (= (+ (tuple_proj<Int-Int>.0 self) 1) (tuple_proj<Int-Int>.0 dist))
+            (= (tuple_proj<Int-Int>.1 self_) (tuple_proj<Int-Int>.1 dist))
+            (= (tuple_proj<Int-Int>.0 self_) item)
+            (= (+ (tuple_proj<Int-Int>.0 self_) 1) (tuple_proj<Int-Int>.0 dist))
         )";
         true
     }

--- a/tests/ui/pass/annot_preds_trait.rs
+++ b/tests/ui/pass/annot_preds_trait.rs
@@ -2,6 +2,7 @@
 //@compile-flags: -Adead_code -C debug-assertions=off
 
 // A is represented as Tuple<Int> in SMT-LIB2 format.
+#[derive(PartialEq)]
 struct A {
     x: i64,
 }
@@ -10,25 +11,27 @@ impl thrust_models::Model for A {
     type Ty = Self;
 }
 
+#[thrust_macros::context]
 trait Double {
     // Support annotations in trait definitions
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool;
 
     // This annotations are applied to all implementors of the `Double` trait.
-    #[thrust::requires(true)]
-    #[thrust::ensures(Self::is_double(*self, ^self))]
+    #[thrust_macros::requires(true)]
+    #[thrust_macros::ensures(Self::is_double(*self, !self))]
     fn double(&mut self);
 }
 
+#[thrust_macros::context]
 impl Double for A {
     // Write concrete definitions for predicates in `impl` blocks
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
         // (tuple_proj<Int>.0 self) is equivalent to self.x
         // self.x * 2 == doubled.x is written as following:
         "(=
-            (* (tuple_proj<Int>.0 self) 2)
+            (* (tuple_proj<Int>.0 self_) 2)
             (tuple_proj<Int>.0 doubled)
         )"; true
     }

--- a/tests/ui/pass/annot_preds_trait_multi.rs
+++ b/tests/ui/pass/annot_preds_trait_multi.rs
@@ -1,14 +1,15 @@
 //@check-pass
 //@compile-flags: -Adead_code -C debug-assertions=off
 
+#[thrust_macros::context]
 trait Double {
     // Support annotations in trait definitions
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool;
 
     // This annotations are applied to all implementors of the `Double` trait.
-    #[thrust::requires(true)]
-    #[thrust::ensures(Self::is_double(*self, ^self))]
+    #[thrust_macros::requires(true)]
+    #[thrust_macros::ensures(Self::is_double(*self, !self))]
     fn double(&mut self);
 }
 
@@ -21,12 +22,13 @@ impl thrust_models::Model for A {
     type Ty = Self;
 }
 
+#[thrust_macros::context]
 impl Double for A {
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
         // self.x * 2 == doubled.x
         "(=
-            (* (tuple_proj<Int>.0 self) 2)
+            (* (tuple_proj<Int>.0 self_) 2)
             (tuple_proj<Int>.0 doubled)
         )"; true
     }
@@ -46,17 +48,18 @@ impl thrust_models::Model for B {
     type Ty = Self;
 }
 
+#[thrust_macros::context]
 impl Double for B {
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
         // self.x * 2 == doubled.x && self.y * 2 == doubled.y
         "(and
             (=
-                (* (tuple_proj<Int-Int>.0 self) 2)
+                (* (tuple_proj<Int-Int>.0 self_) 2)
                 (tuple_proj<Int-Int>.0 doubled)
             )
             (=
-                (* (tuple_proj<Int-Int>.1 self) 2)
+                (* (tuple_proj<Int-Int>.1 self_) 2)
                 (tuple_proj<Int-Int>.1 doubled)
             )
         )"; true

--- a/tests/ui/pass/iterators/annot_range_loop.rs
+++ b/tests/ui/pass/iterators/annot_range_loop.rs
@@ -2,19 +2,20 @@
 //@compile-flags: -C debug-assertions=off
 //@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper THRUST_SOLVER_TIMEOUT_SECS=60
 
+#[thrust_macros::context]
 trait Iterator {
     type Item;
 
-    #[thrust::requires(true)]
-    #[thrust::ensures(
-        (Self::completed(*self) || (exists i:int. (result == std::option::Option::<int>::Some(i)) && Self::step(*self, i, ^self)))
-        && (!Self::completed(*self) || (result == std::option::Option::<int>::None() && *self == ^self))
+    #[thrust_macros::ensures(
+        Self::completed(*self)
+        || thrust_models::exists(|i| (result == Some(i)) && Self::step(*self, i, !self))
     )]
+    #[thrust_macros::ensures(!Self::completed(*self) || (result == None && *self == !self))]
     fn next(&mut self) -> Option<Self::Item>;
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn completed(self) -> bool;
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn step(self, item: Self::Item, dist: Self) -> bool;
 }
 
@@ -27,6 +28,7 @@ impl thrust_models::Model for Range {
     type Ty = Range;
 }
 
+#[thrust_macros::context]
 impl Iterator for Range {
     type Item = i64;
 
@@ -40,25 +42,25 @@ impl Iterator for Range {
         }
     }
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn completed(self) -> bool {
         // (tuple_proj<Int-Int>.0 self) is equivalent to self.start
         // !(self.start < self.end) is written as following:
         "(not (<
-            (tuple_proj<Int-Int>.0 self)
-            (tuple_proj<Int-Int>.1 self)
+            (tuple_proj<Int-Int>.0 self_)
+            (tuple_proj<Int-Int>.1 self_)
         ))";
         true
     }
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn step(self, item: Self::Item, dist: Self) -> bool {
         // self.end == dist.end && self.start == item && self.start + 1 == dist.start
         // is written as following:
         "(and
-            (= (tuple_proj<Int-Int>.1 self) (tuple_proj<Int-Int>.1 dist))
-            (= (tuple_proj<Int-Int>.0 self) item)
-            (= (+ (tuple_proj<Int-Int>.0 self) 1) (tuple_proj<Int-Int>.0 dist))
+            (= (tuple_proj<Int-Int>.1 self_) (tuple_proj<Int-Int>.1 dist))
+            (= (tuple_proj<Int-Int>.0 self_) item)
+            (= (+ (tuple_proj<Int-Int>.0 self_) 1) (tuple_proj<Int-Int>.0 dist))
         )";
         true
     }

--- a/tests/ui/pass/iterators/annot_range_next.rs
+++ b/tests/ui/pass/iterators/annot_range_next.rs
@@ -2,19 +2,20 @@
 //@compile-flags: -C debug-assertions=off
 //@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
 
+#[thrust_macros::context]
 trait Iterator {
     type Item;
 
-    #[thrust::requires(true)]
-    #[thrust::ensures(
-        (Self::completed(*self) || (exists i:int. (result == std::option::Option::<int>::Some(i)) && Self::step(*self, i, ^self)))
-        && (!Self::completed(*self) || (result == std::option::Option::<int>::None() && *self == ^self))
+    #[thrust_macros::ensures(
+        Self::completed(*self)
+        || thrust_models::exists(|i| (result == Some(i)) && Self::step(*self, i, !self))
     )]
+    #[thrust_macros::ensures(!Self::completed(*self) || (result == None && *self == !self))]
     fn next(&mut self) -> Option<Self::Item>;
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn completed(self) -> bool;
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn step(self, item: Self::Item, dist: Self) -> bool;
 }
 
@@ -27,6 +28,7 @@ impl thrust_models::Model for Range {
     type Ty = Range;
 }
 
+#[thrust_macros::context]
 impl Iterator for Range {
     type Item = i64;
 
@@ -40,25 +42,25 @@ impl Iterator for Range {
         }
     }
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn completed(self) -> bool {
         // (tuple_proj<Int-Int>.0 self) is equivalent to self.start
         // !(self.start < self.end) is written as following:
         "(not (<
-            (tuple_proj<Int-Int>.0 self)
-            (tuple_proj<Int-Int>.1 self)
+            (tuple_proj<Int-Int>.0 self_)
+            (tuple_proj<Int-Int>.1 self_)
         ))";
         true
     }
 
-    #[thrust::predicate]
+    #[thrust_macros::predicate]
     fn step(self, item: Self::Item, dist: Self) -> bool {
         // self.end == dist.end && self.start == item && self.start + 1 == dist.start
         // is written as following:
         "(and
-            (= (tuple_proj<Int-Int>.1 self) (tuple_proj<Int-Int>.1 dist))
-            (= (tuple_proj<Int-Int>.0 self) item)
-            (= (+ (tuple_proj<Int-Int>.0 self) 1) (tuple_proj<Int-Int>.0 dist))
+            (= (tuple_proj<Int-Int>.1 self_) (tuple_proj<Int-Int>.1 dist))
+            (= (tuple_proj<Int-Int>.0 self_) item)
+            (= (+ (tuple_proj<Int-Int>.0 self_) 1) (tuple_proj<Int-Int>.0 dist))
         )";
         true
     }

--- a/thrust-macros/src/lib.rs
+++ b/thrust-macros/src/lib.rs
@@ -715,16 +715,55 @@ fn model_where_predicates(
             });
         }
     }
+    generic_type_params.retain(|p| !p.has_fn_bound());
 
     let mut predicates: Vec<WherePredicate> = Vec::new();
-    for param in generic_type_params {
-        if param.has_fn_bound() {
-            continue;
-        }
+    for param in &generic_type_params {
         let ident = &param.ident;
         predicates.push(syn::parse_quote!(#ident: thrust_models::Model));
         predicates.push(syn::parse_quote!(<#ident as thrust_models::Model>::Ty: PartialEq));
     }
+
+    struct Visitor {
+        generic_type_params: Vec<GenericTypeParam>,
+        generic_paths: Vec<syn::TypePath>,
+    }
+
+    impl syn::visit::Visit<'_> for Visitor {
+        fn visit_type_path(&mut self, tp: &syn::TypePath) {
+            for param in &self.generic_type_params {
+                if let Some(qself) = &tp.qself {
+                    let param = &param.ident;
+                    let param_ty: syn::Type = syn::parse_quote!(#param);
+                    if *qself.ty == param_ty {
+                        self.generic_paths.push(tp.clone());
+                    }
+                }
+                if tp.path.segments.len() > 1
+                    && tp.path.segments.first().unwrap().ident == param.ident
+                    && tp.qself.is_none()
+                {
+                    self.generic_paths.push(tp.clone());
+                }
+            }
+            syn::visit::visit_type_path(self, tp);
+        }
+    }
+
+    let mut visitor = Visitor {
+        generic_type_params,
+        generic_paths: Vec::new(),
+    };
+    use syn::visit::Visit as _;
+    for arg in &func.sig().inputs {
+        visitor.visit_fn_arg(arg);
+    }
+    visitor.visit_return_type(&func.sig().output);
+    for tp in visitor.generic_paths {
+        predicates.push(syn::parse_quote!(#tp: thrust_models::Model));
+        predicates.push(syn::parse_quote!(<#tp as thrust_models::Model>::Ty: PartialEq));
+    }
+
     predicates
 }
 

--- a/thrust-macros/src/lib.rs
+++ b/thrust-macros/src/lib.rs
@@ -2,8 +2,8 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use syn::{
-    parse_macro_input, punctuated::Punctuated, FnArg, GenericParam, Generics, ReturnType, Type,
-    TypeParamBound, WherePredicate,
+    parse_macro_input, punctuated::Punctuated, FnArg, GenericParam, Generics, TypeParamBound,
+    WherePredicate,
 };
 
 #[derive(Debug, Clone)]
@@ -135,6 +135,14 @@ impl quote::ToTokens for FnItemWithSignature {
 }
 
 impl FnItemWithSignature {
+    fn block(&self) -> Option<&syn::Block> {
+        match self {
+            FnItemWithSignature::ItemFn(item_fn) => Some(&item_fn.block),
+            FnItemWithSignature::ImplItemFn(impl_item_fn) => Some(&impl_item_fn.block),
+            FnItemWithSignature::TraitItemFn(_) => None,
+        }
+    }
+
     fn block_mut(&mut self) -> Option<&mut syn::Block> {
         match self {
             FnItemWithSignature::ItemFn(item_fn) => Some(&mut item_fn.block),
@@ -165,6 +173,37 @@ impl FnItemWithSignature {
             FnItemWithSignature::ImplItemFn(impl_item_fn) => &impl_item_fn.sig,
             FnItemWithSignature::TraitItemFn(trait_item_fn) => &trait_item_fn.sig,
         }
+    }
+}
+
+#[proc_macro_attribute]
+pub fn predicate(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let func = parse_macro_input!(item as FnItemWithSignature);
+    let outer_context = match extract_outer_context(&func) {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            let err = e.to_compile_error();
+            return quote! { #err #func }.into();
+        }
+    };
+
+    let name = &func.sig().ident;
+    let def_generics = generic_params_tokens(&func.sig().generics);
+    let model_ty_params = fn_params_with_model_ty(&func.sig().inputs);
+    let model_ret = fn_return_ty_with_model_ty(&func.sig().output);
+
+    let model_preds = model_where_predicates(&func, outer_context.as_ref());
+    let extended_where = extended_where_clause(&func, &model_preds);
+
+    let sig = quote! {
+        #[allow(dead_code)]
+        #[thrust::predicate]
+        fn #name #def_generics(#model_ty_params) -> #model_ret #extended_where
+    };
+    if let Some(block) = func.block() {
+        quote! { #sig #block }.into()
+    } else {
+        quote! { #sig; }.into()
     }
 }
 
@@ -261,16 +300,11 @@ pub fn _requires_ensures(attr: TokenStream, item: TokenStream) -> TokenStream {
     let func = parse_macro_input!(item as FnItemWithSignature);
     let outer_context = match extract_outer_context(&func) {
         Ok(ctx) => ctx,
-        Err(e) => return e.to_compile_error().into(),
+        Err(e) => {
+            let err = e.to_compile_error();
+            return quote! { #err #func }.into();
+        }
     };
-    if mentions_self(func.sig()) && outer_context.is_none() {
-        let err = syn::Error::new_spanned(
-            func.sig().ident.clone(),
-            "Wrap impl block with #[thrust_macros::context] to use requires/ensures on methods",
-        )
-        .to_compile_error();
-        return quote! { #err #func }.into();
-    }
     let mut tokens = ExpandedTokens::new(func, req_expr, ens_expr);
     if let Some(ctx) = outer_context {
         tokens = tokens.with_outer_context(ctx);
@@ -295,6 +329,12 @@ fn extract_outer_context(func: &FnItemWithSignature) -> syn::Result<Option<FnOut
         }
         outer_context = Some(item);
     }
+    if mentions_self(func.sig()) && outer_context.is_none() {
+        return Err(syn::Error::new_spanned(
+            func.sig().ident.clone(),
+            "Wrap the surrounding impl block or trait definition with #[thrust_macros::context] to annotate methods",
+        ));
+    }
     Ok(outer_context)
 }
 
@@ -310,7 +350,7 @@ struct ExpandedTokens {
     turbofish: TokenStream2,
 
     model_ty_params: TokenStream2,
-    ret_model_ty: Type,
+    ret_model_ty: syn::Type,
 
     outer_context: Option<FnOuterItem>,
 }
@@ -340,10 +380,7 @@ impl ExpandedTokens {
         let turbofish = generic_turbofish(generics);
 
         let model_ty_params = fn_params_with_model_ty(&func.sig().inputs);
-        let ret_model_ty: Type = match &func.sig().output {
-            ReturnType::Default => syn::parse_quote!(<() as thrust_models::Model>::Ty),
-            ReturnType::Type(_, ty) => syn::parse_quote!(<#ty as thrust_models::Model>::Ty),
-        };
+        let ret_model_ty = fn_return_ty_with_model_ty(&func.sig().output);
 
         if func.sig().receiver().is_some() {
             rewrite_self_in_expr(&mut req_expr);
@@ -369,88 +406,9 @@ impl ExpandedTokens {
         self
     }
 
-    /// Returns `T: thrust_models::Model` predicates for every type param that does not
-    /// already carry an `Fn`, `FnOnce`, or `FnMut` bound.
-    fn model_where_predicates(&self) -> Vec<WherePredicate> {
-        struct GenericTypeParam {
-            ident: syn::Ident,
-            bounds: Vec<TypeParamBound>,
-        }
-
-        impl From<syn::TypeParam> for GenericTypeParam {
-            fn from(tp: syn::TypeParam) -> Self {
-                Self {
-                    ident: tp.ident,
-                    bounds: tp.bounds.into_iter().collect(),
-                }
-            }
-        }
-
-        impl GenericTypeParam {
-            fn has_fn_bound(&self) -> bool {
-                self.bounds.iter().any(|b| {
-                    let TypeParamBound::Trait(tb) = b else {
-                        return false;
-                    };
-                    tb.path.segments.last().map_or(false, |s| {
-                        matches!(s.ident.to_string().as_str(), "Fn" | "FnOnce" | "FnMut")
-                    })
-                })
-            }
-        }
-
-        let mut generic_type_params: Vec<GenericTypeParam> = Vec::new();
-        for param in &self.func.sig().generics.params {
-            let GenericParam::Type(tp) = param else {
-                continue;
-            };
-            generic_type_params.push(tp.clone().into());
-        }
-        if let Some(outer_item) = &self.outer_context {
-            for param in &outer_item.generics().params {
-                let GenericParam::Type(tp) = param else {
-                    continue;
-                };
-                generic_type_params.push(tp.clone().into());
-            }
-            if let FnOuterItem::ItemTrait(outer_item) = &outer_item {
-                generic_type_params.push(GenericTypeParam {
-                    ident: format_ident!("Self"),
-                    bounds: outer_item.supertraits.iter().cloned().collect(),
-                });
-            }
-        }
-
-        let mut predicates: Vec<WherePredicate> = Vec::new();
-        for param in generic_type_params {
-            if param.has_fn_bound() {
-                continue;
-            }
-            let ident = &param.ident;
-            predicates.push(syn::parse_quote!(#ident: thrust_models::Model));
-            predicates.push(syn::parse_quote!(<#ident as thrust_models::Model>::Ty: PartialEq));
-        }
-        predicates
-    }
-
-    /// Builds `where <original predicates>, <model predicates>`.
-    /// Returns an empty token stream when both sets are empty.
     fn extended_where_clause(&self) -> TokenStream2 {
-        let model_preds = self.model_where_predicates();
-        let existing: Vec<&WherePredicate> = self
-            .func
-            .sig()
-            .generics
-            .where_clause
-            .as_ref()
-            .map(|wc| wc.predicates.iter().collect())
-            .unwrap_or_default();
-
-        if existing.is_empty() && model_preds.is_empty() {
-            return quote!();
-        }
-
-        quote! { where #(#existing,)* #(#model_preds),* }
+        let model_preds = model_where_predicates(&self.func, self.outer_context.as_ref());
+        extended_where_clause(&self.func, &model_preds)
     }
 
     fn is_extern_spec_fn(&self) -> bool {
@@ -701,4 +659,99 @@ fn rewrite_inputs_for_call(
     }
 
     (quote!(#(#rewritten),*), quote!(#(#call_args),*))
+}
+
+/// Returns `T: thrust_models::Model` predicates for every type param that does not
+/// already carry an `Fn`, `FnOnce`, or `FnMut` bound.
+fn model_where_predicates(
+    func: &FnItemWithSignature,
+    outer_context: Option<&FnOuterItem>,
+) -> Vec<WherePredicate> {
+    struct GenericTypeParam {
+        ident: syn::Ident,
+        bounds: Vec<TypeParamBound>,
+    }
+
+    impl From<syn::TypeParam> for GenericTypeParam {
+        fn from(tp: syn::TypeParam) -> Self {
+            Self {
+                ident: tp.ident,
+                bounds: tp.bounds.into_iter().collect(),
+            }
+        }
+    }
+
+    impl GenericTypeParam {
+        fn has_fn_bound(&self) -> bool {
+            self.bounds.iter().any(|b| {
+                let TypeParamBound::Trait(tb) = b else {
+                    return false;
+                };
+                tb.path.segments.last().map_or(false, |s| {
+                    matches!(s.ident.to_string().as_str(), "Fn" | "FnOnce" | "FnMut")
+                })
+            })
+        }
+    }
+
+    let mut generic_type_params: Vec<GenericTypeParam> = Vec::new();
+    for param in &func.sig().generics.params {
+        let GenericParam::Type(tp) = param else {
+            continue;
+        };
+        generic_type_params.push(tp.clone().into());
+    }
+    if let Some(outer_item) = outer_context {
+        for param in &outer_item.generics().params {
+            let GenericParam::Type(tp) = param else {
+                continue;
+            };
+            generic_type_params.push(tp.clone().into());
+        }
+        if let FnOuterItem::ItemTrait(outer_item) = &outer_item {
+            generic_type_params.push(GenericTypeParam {
+                ident: format_ident!("Self"),
+                bounds: outer_item.supertraits.iter().cloned().collect(),
+            });
+        }
+    }
+
+    let mut predicates: Vec<WherePredicate> = Vec::new();
+    for param in generic_type_params {
+        if param.has_fn_bound() {
+            continue;
+        }
+        let ident = &param.ident;
+        predicates.push(syn::parse_quote!(#ident: thrust_models::Model));
+        predicates.push(syn::parse_quote!(<#ident as thrust_models::Model>::Ty: PartialEq));
+    }
+    predicates
+}
+
+/// Builds `where <original predicates>, <model predicates>`.
+/// Returns an empty token stream when both sets are empty.
+fn extended_where_clause(
+    func: &FnItemWithSignature,
+    model_preds: &Vec<syn::WherePredicate>,
+) -> TokenStream2 {
+    let existing: Vec<&WherePredicate> = func
+        .sig()
+        .generics
+        .where_clause
+        .as_ref()
+        .map(|wc| wc.predicates.iter().collect())
+        .unwrap_or_default();
+
+    if existing.is_empty() && model_preds.is_empty() {
+        return quote!();
+    }
+
+    quote! { where #(#existing,)* #(#model_preds),* }
+}
+
+fn fn_return_ty_with_model_ty(ret: &syn::ReturnType) -> syn::Type {
+    match ret {
+        syn::ReturnType::Default => syn::parse_quote!(<() as thrust_models::Model>::Ty),
+        syn::ReturnType::Type(_, ty) => syn::parse_quote!(<#ty as thrust_models::Model>::Ty),
+    }
 }

--- a/thrust-macros/src/lib.rs
+++ b/thrust-macros/src/lib.rs
@@ -2,39 +2,182 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, ToTokens};
 use syn::{
-    parse_macro_input, punctuated::Punctuated, FnArg, GenericParam, Generics, ItemFn, ReturnType,
-    Type, TypeParamBound, WherePredicate,
+    parse_macro_input, punctuated::Punctuated, FnArg, GenericParam, Generics, ReturnType, Type,
+    TypeParamBound, WherePredicate,
 };
+
+#[derive(Debug, Clone)]
+enum FnOuterItem {
+    ItemImpl(syn::ItemImpl),
+    ItemTrait(syn::ItemTrait),
+}
+
+impl syn::parse::Parse for FnOuterItem {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        use syn::parse::discouraged::Speculative as _;
+
+        let fork = input.fork();
+        if let Ok(item_impl) = fork.parse::<syn::ItemImpl>() {
+            input.advance_to(&fork);
+            return Ok(Self::ItemImpl(item_impl));
+        }
+
+        let fork = input.fork();
+        if let Ok(item_trait) = fork.parse::<syn::ItemTrait>() {
+            input.advance_to(&fork);
+            return Ok(Self::ItemTrait(item_trait));
+        }
+
+        Err(input.error("expected an impl block or a trait definition"))
+    }
+}
+
+impl quote::ToTokens for FnOuterItem {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        match self {
+            FnOuterItem::ItemImpl(item_impl) => item_impl.to_tokens(tokens),
+            FnOuterItem::ItemTrait(item_trait) => item_trait.to_tokens(tokens),
+        }
+    }
+}
+
+impl FnOuterItem {
+    fn into_header_only(mut self) -> Self {
+        match &mut self {
+            FnOuterItem::ItemImpl(item_impl) => {
+                item_impl.items.clear();
+            }
+            FnOuterItem::ItemTrait(item_trait) => {
+                item_trait.items.clear();
+            }
+        }
+        self
+    }
+
+    fn generics(&self) -> &Generics {
+        match self {
+            FnOuterItem::ItemImpl(item_impl) => &item_impl.generics,
+            FnOuterItem::ItemTrait(item_trait) => &item_trait.generics,
+        }
+    }
+}
 
 #[proc_macro_attribute]
 pub fn context(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let mut impl_item = syn::parse_macro_input!(item as syn::ItemImpl);
-    let impl_header = {
-        let mut header = impl_item.clone();
-        header.items.clear();
-        header
-    };
-    for item in &mut impl_item.items {
-        let syn::ImplItem::Fn(item) = item else {
-            continue;
-        };
-        // TODO: why ::thrust_macros doesn't work here?
-        item.attrs
-            .push(syn::parse_quote!(#[thrust::_impl_context(#impl_header)]));
+    let mut outer_item = syn::parse_macro_input!(item as FnOuterItem);
+    let outer_header = outer_item.clone().into_header_only();
+    match &mut outer_item {
+        FnOuterItem::ItemImpl(item_impl) => {
+            for item in &mut item_impl.items {
+                let syn::ImplItem::Fn(item) = item else {
+                    continue;
+                };
+                item.attrs
+                    .push(syn::parse_quote!(#[thrust::_outer_context(#outer_header)]));
+            }
+        }
+        FnOuterItem::ItemTrait(item_trait) => {
+            for item in &mut item_trait.items {
+                let syn::TraitItem::Fn(item) = item else {
+                    continue;
+                };
+                item.attrs
+                    .push(syn::parse_quote!(#[thrust::_outer_context(#outer_header)]));
+            }
+        }
     }
-    impl_item.into_token_stream().into()
+
+    outer_item.into_token_stream().into()
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone)]
+enum FnItemWithSignature {
+    ItemFn(syn::ItemFn),
+    ImplItemFn(syn::ImplItemFn),
+    TraitItemFn(syn::TraitItemFn),
+}
+
+impl syn::parse::Parse for FnItemWithSignature {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        use syn::parse::discouraged::Speculative as _;
+
+        let fork = input.fork();
+        if let Ok(item_fn) = fork.parse::<syn::ItemFn>() {
+            input.advance_to(&fork);
+            return Ok(Self::ItemFn(item_fn));
+        }
+
+        let fork = input.fork();
+        if let Ok(impl_item_fn) = fork.parse::<syn::ImplItemFn>() {
+            input.advance_to(&fork);
+            return Ok(Self::ImplItemFn(impl_item_fn));
+        }
+
+        let fork = input.fork();
+        if let Ok(trait_item_fn) = fork.parse::<syn::TraitItemFn>() {
+            input.advance_to(&fork);
+            return Ok(Self::TraitItemFn(trait_item_fn));
+        }
+
+        Err(input.error("expected a free function, an impl method, or a trait method"))
+    }
+}
+
+impl quote::ToTokens for FnItemWithSignature {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        match self {
+            FnItemWithSignature::ItemFn(item_fn) => item_fn.to_tokens(tokens),
+            FnItemWithSignature::ImplItemFn(impl_item_fn) => impl_item_fn.to_tokens(tokens),
+            FnItemWithSignature::TraitItemFn(trait_item_fn) => trait_item_fn.to_tokens(tokens),
+        }
+    }
+}
+
+impl FnItemWithSignature {
+    fn block_mut(&mut self) -> Option<&mut syn::Block> {
+        match self {
+            FnItemWithSignature::ItemFn(item_fn) => Some(&mut item_fn.block),
+            FnItemWithSignature::ImplItemFn(impl_item_fn) => Some(&mut impl_item_fn.block),
+            FnItemWithSignature::TraitItemFn(_) => None,
+        }
+    }
+
+    fn attrs(&self) -> &[syn::Attribute] {
+        match self {
+            FnItemWithSignature::ItemFn(item_fn) => &item_fn.attrs,
+            FnItemWithSignature::ImplItemFn(impl_item_fn) => &impl_item_fn.attrs,
+            FnItemWithSignature::TraitItemFn(trait_item_fn) => &trait_item_fn.attrs,
+        }
+    }
+
+    fn attrs_mut(&mut self) -> &mut Vec<syn::Attribute> {
+        match self {
+            FnItemWithSignature::ItemFn(item_fn) => &mut item_fn.attrs,
+            FnItemWithSignature::ImplItemFn(impl_item_fn) => &mut impl_item_fn.attrs,
+            FnItemWithSignature::TraitItemFn(trait_item_fn) => &mut trait_item_fn.attrs,
+        }
+    }
+
+    fn sig(&self) -> &syn::Signature {
+        match self {
+            FnItemWithSignature::ItemFn(item_fn) => &item_fn.sig,
+            FnItemWithSignature::ImplItemFn(impl_item_fn) => &impl_item_fn.sig,
+            FnItemWithSignature::TraitItemFn(trait_item_fn) => &trait_item_fn.sig,
+        }
+    }
 }
 
 #[proc_macro_attribute]
 pub fn requires(attr: TokenStream, item: TokenStream) -> TokenStream {
     let expr = TokenStream2::from(attr);
-    let mut func = parse_macro_input!(item as ItemFn);
+    let mut func = parse_macro_input!(item as FnItemWithSignature);
 
     let (req_expr, ens_expr) = match extract_requires_ensures(&mut func) {
         Ok((req, ens)) => (req, ens),
         Err(e) => return e.to_compile_error().into(),
     };
-    func.attrs.push(syn::parse_quote!(
+    func.attrs_mut().push(syn::parse_quote!(
         #[::thrust_macros::_requires_ensures((#req_expr) && (#expr), #ens_expr)]
     ));
 
@@ -44,25 +187,25 @@ pub fn requires(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn ensures(attr: TokenStream, item: TokenStream) -> TokenStream {
     let expr = TokenStream2::from(attr);
-    let mut func = parse_macro_input!(item as ItemFn);
+    let mut func = parse_macro_input!(item as FnItemWithSignature);
 
     let (req_expr, ens_expr) = match extract_requires_ensures(&mut func) {
         Ok((req, ens)) => (req, ens),
         Err(e) => return e.to_compile_error().into(),
     };
-    func.attrs.push(syn::parse_quote!(
+    func.attrs_mut().push(syn::parse_quote!(
         #[::thrust_macros::_requires_ensures(#req_expr, (#ens_expr) && (#expr))]
     ));
 
     func.into_token_stream().into()
 }
 
-fn extract_requires_ensures(func: &mut ItemFn) -> syn::Result<(syn::Expr, syn::Expr)> {
+fn extract_requires_ensures(func: &mut FnItemWithSignature) -> syn::Result<(syn::Expr, syn::Expr)> {
     let mut result = None;
 
     let requires_ensures_path: syn::Path = syn::parse_quote!(::thrust_macros::_requires_ensures);
 
-    for attr in &func.attrs {
+    for attr in func.attrs() {
         if attr.path() == &requires_ensures_path {
             if result.is_some() {
                 return Err(syn::Error::new_spanned(
@@ -85,7 +228,7 @@ fn extract_requires_ensures(func: &mut ItemFn) -> syn::Result<(syn::Expr, syn::E
         }
     }
 
-    func.attrs
+    func.attrs_mut()
         .retain(|attr| attr.path() != &requires_ensures_path);
 
     if let Some((req_expr, ens_expr)) = result {
@@ -115,48 +258,48 @@ pub fn _requires_ensures(attr: TokenStream, item: TokenStream) -> TokenStream {
     let ens_expr = exprs.pop().unwrap().into_value();
     let req_expr = exprs.pop().unwrap().into_value();
 
-    let func = parse_macro_input!(item as ItemFn);
-    let impl_context = match extract_impl_context(&func) {
+    let func = parse_macro_input!(item as FnItemWithSignature);
+    let outer_context = match extract_outer_context(&func) {
         Ok(ctx) => ctx,
         Err(e) => return e.to_compile_error().into(),
     };
-    if mentions_self(&func.sig) && impl_context.is_none() {
+    if mentions_self(func.sig()) && outer_context.is_none() {
         let err = syn::Error::new_spanned(
-            func.sig.ident.clone(),
+            func.sig().ident.clone(),
             "Wrap impl block with #[thrust_macros::context] to use requires/ensures on methods",
         )
         .to_compile_error();
         return quote! { #err #func }.into();
     }
     let mut tokens = ExpandedTokens::new(func, req_expr, ens_expr);
-    if let Some(ctx) = impl_context {
-        tokens = tokens.with_impl_context(ctx);
+    if let Some(ctx) = outer_context {
+        tokens = tokens.with_outer_context(ctx);
     }
     tokens.into_token_stream().into()
 }
 
-fn extract_impl_context(func: &syn::ItemFn) -> syn::Result<Option<syn::ItemImpl>> {
-    let impl_context_path: syn::Path = syn::parse_quote!(thrust::_impl_context);
-    let mut impl_context = None;
-    for attr in &func.attrs {
-        if attr.path() != &impl_context_path {
+fn extract_outer_context(func: &FnItemWithSignature) -> syn::Result<Option<FnOuterItem>> {
+    let outer_context_path: syn::Path = syn::parse_quote!(thrust::_outer_context);
+    let mut outer_context = None;
+    for attr in func.attrs() {
+        if attr.path() != &outer_context_path {
             continue;
         }
 
         let item = attr.parse_args()?;
-        if impl_context.is_some() {
+        if outer_context.is_some() {
             return Err(syn::Error::new_spanned(
                 attr,
-                "multiple _impl_context attributes found; expected at most one",
+                "multiple _outer_context attributes found; expected at most one",
             ));
         }
-        impl_context = Some(item);
+        outer_context = Some(item);
     }
-    Ok(impl_context)
+    Ok(outer_context)
 }
 
 struct ExpandedTokens {
-    func: ItemFn,
+    func: FnItemWithSignature,
 
     requires_name: syn::Ident,
     ensures_name: syn::Ident,
@@ -169,7 +312,7 @@ struct ExpandedTokens {
     model_ty_params: TokenStream2,
     ret_model_ty: Type,
 
-    impl_context: Option<syn::ItemImpl>,
+    outer_context: Option<FnOuterItem>,
 }
 
 impl quote::ToTokens for ExpandedTokens {
@@ -183,22 +326,26 @@ impl quote::ToTokens for ExpandedTokens {
 }
 
 impl ExpandedTokens {
-    pub fn new(func: ItemFn, mut req_expr: syn::Expr, mut ens_expr: syn::Expr) -> Self {
-        let name = &func.sig.ident;
+    pub fn new(
+        func: FnItemWithSignature,
+        mut req_expr: syn::Expr,
+        mut ens_expr: syn::Expr,
+    ) -> Self {
+        let name = &func.sig().ident;
         let requires_name = format_ident!("_thrust_requires_{}", name);
         let ensures_name = format_ident!("_thrust_ensures_{}", name);
 
-        let generics = &func.sig.generics;
+        let generics = &func.sig().generics;
         let def_generics = generic_params_tokens(generics);
         let turbofish = generic_turbofish(generics);
 
-        let model_ty_params = fn_params_with_model_ty(&func.sig.inputs);
-        let ret_model_ty: Type = match &func.sig.output {
+        let model_ty_params = fn_params_with_model_ty(&func.sig().inputs);
+        let ret_model_ty: Type = match &func.sig().output {
             ReturnType::Default => syn::parse_quote!(<() as thrust_models::Model>::Ty),
             ReturnType::Type(_, ty) => syn::parse_quote!(<#ty as thrust_models::Model>::Ty),
         };
 
-        if func.sig.receiver().is_some() {
+        if func.sig().receiver().is_some() {
             rewrite_self_in_expr(&mut req_expr);
             rewrite_self_in_expr(&mut ens_expr);
         }
@@ -213,45 +360,70 @@ impl ExpandedTokens {
             turbofish,
             model_ty_params,
             ret_model_ty,
-            impl_context: None,
+            outer_context: None,
         }
     }
 
-    pub fn with_impl_context(mut self, impl_item: syn::ItemImpl) -> Self {
-        self.impl_context = Some(impl_item);
+    pub fn with_outer_context(mut self, outer_item: FnOuterItem) -> Self {
+        self.outer_context = Some(outer_item);
         self
     }
 
     /// Returns `T: thrust_models::Model` predicates for every type param that does not
     /// already carry an `Fn`, `FnOnce`, or `FnMut` bound.
     fn model_where_predicates(&self) -> Vec<WherePredicate> {
-        let mut generic_type_params: Vec<&syn::TypeParam> = Vec::new();
-        for param in &self.func.sig.generics.params {
+        struct GenericTypeParam {
+            ident: syn::Ident,
+            bounds: Vec<TypeParamBound>,
+        }
+
+        impl From<syn::TypeParam> for GenericTypeParam {
+            fn from(tp: syn::TypeParam) -> Self {
+                Self {
+                    ident: tp.ident,
+                    bounds: tp.bounds.into_iter().collect(),
+                }
+            }
+        }
+
+        impl GenericTypeParam {
+            fn has_fn_bound(&self) -> bool {
+                self.bounds.iter().any(|b| {
+                    let TypeParamBound::Trait(tb) = b else {
+                        return false;
+                    };
+                    tb.path.segments.last().map_or(false, |s| {
+                        matches!(s.ident.to_string().as_str(), "Fn" | "FnOnce" | "FnMut")
+                    })
+                })
+            }
+        }
+
+        let mut generic_type_params: Vec<GenericTypeParam> = Vec::new();
+        for param in &self.func.sig().generics.params {
             let GenericParam::Type(tp) = param else {
                 continue;
             };
-            generic_type_params.push(tp);
+            generic_type_params.push(tp.clone().into());
         }
-        if let Some(impl_item) = &self.impl_context {
-            for param in &impl_item.generics.params {
+        if let Some(outer_item) = &self.outer_context {
+            for param in &outer_item.generics().params {
                 let GenericParam::Type(tp) = param else {
                     continue;
                 };
-                generic_type_params.push(tp);
+                generic_type_params.push(tp.clone().into());
+            }
+            if let FnOuterItem::ItemTrait(outer_item) = &outer_item {
+                generic_type_params.push(GenericTypeParam {
+                    ident: format_ident!("Self"),
+                    bounds: outer_item.supertraits.iter().cloned().collect(),
+                });
             }
         }
 
         let mut predicates: Vec<WherePredicate> = Vec::new();
         for param in generic_type_params {
-            let has_fn_bound = param.bounds.iter().any(|b| {
-                let TypeParamBound::Trait(tb) = b else {
-                    return false;
-                };
-                tb.path.segments.last().map_or(false, |s| {
-                    matches!(s.ident.to_string().as_str(), "Fn" | "FnOnce" | "FnMut")
-                })
-            });
-            if has_fn_bound {
+            if param.has_fn_bound() {
                 continue;
             }
             let ident = &param.ident;
@@ -267,7 +439,7 @@ impl ExpandedTokens {
         let model_preds = self.model_where_predicates();
         let existing: Vec<&WherePredicate> = self
             .func
-            .sig
+            .sig()
             .generics
             .where_clause
             .as_ref()
@@ -284,7 +456,7 @@ impl ExpandedTokens {
     fn is_extern_spec_fn(&self) -> bool {
         let extern_spec_fn_path: syn::Path = syn::parse_quote!(thrust::extern_spec_fn);
         self.func
-            .attrs
+            .attrs()
             .iter()
             .any(|a| a.path() == &extern_spec_fn_path)
     }
@@ -325,14 +497,14 @@ impl ExpandedTokens {
     }
 
     fn path_prefix(&self) -> Option<TokenStream2> {
-        self.impl_context.as_ref()?;
+        self.outer_context.as_ref()?;
         Some(quote!(Self::))
     }
 
     fn expand(&self) -> TokenStream2 {
         let mut func = self.func.clone();
         let trusted_path: syn::Path = syn::parse_quote!(thrust::trusted);
-        for attr in &mut func.attrs {
+        for attr in func.attrs_mut() {
             if attr.path() == &trusted_path {
                 *attr = syn::parse_quote!(#[thrust::ignored]);
             }
@@ -341,9 +513,9 @@ impl ExpandedTokens {
         let requires_fn = self.requires_fn();
         let ensures_fn = self.ensures_fn();
 
-        let extern_spec_name = format_ident!("_thrust_extern_spec_{}", self.func.sig.ident);
+        let extern_spec_name = format_ident!("_thrust_extern_spec_{}", self.func.sig().ident);
         let def_generics = &self.def_generics;
-        let orig_output = &self.func.sig.output;
+        let orig_output = &self.func.sig().output;
         let extended_where = self.extended_where_clause();
 
         let requires_name = &self.requires_name;
@@ -351,8 +523,8 @@ impl ExpandedTokens {
         let turbofish = &self.turbofish;
         let path_prefix = self.path_prefix();
 
-        let name = &self.func.sig.ident;
-        let (extern_spec_inputs, call_args) = rewrite_inputs_for_call(&self.func.sig.inputs);
+        let name = &self.func.sig().ident;
+        let (extern_spec_inputs, call_args) = rewrite_inputs_for_call(&self.func.sig().inputs);
 
         quote! {
             #func
@@ -381,16 +553,32 @@ impl ExpandedTokens {
         let path_prefix = self.path_prefix();
 
         let mut func = self.func.clone();
-        let orig_stmts = func.block.stmts.clone();
-        func.block = syn::parse_quote!({
-            #[thrust::requires_path]
-            #path_prefix #requires_name #turbofish;
+        let func_tokens = if let Some(block) = func.block_mut() {
+            let orig_stmts = block.stmts.drain(..).collect::<Vec<_>>();
+            *block = syn::parse_quote!({
+                #[thrust::requires_path]
+                #path_prefix #requires_name #turbofish;
 
-            #[thrust::ensures_path]
-            #path_prefix #ensures_name #turbofish;
+                #[thrust::ensures_path]
+                #path_prefix #ensures_name #turbofish;
 
-            #(#orig_stmts)*
-        });
+                #(#orig_stmts)*
+            });
+            quote! {
+                #[allow(path_statements)]
+                #func
+            }
+        } else {
+            let error = syn::Error::new_spanned(
+                func.sig().ident.clone(),
+                "extern_spec_fn must have a function body",
+            )
+            .into_compile_error();
+            quote! {
+                #error
+                #func
+            }
+        };
 
         let requires_fn = self.requires_fn();
         let ensures_fn = self.ensures_fn();
@@ -399,8 +587,7 @@ impl ExpandedTokens {
             #requires_fn
             #ensures_fn
 
-            #[allow(path_statements)]
-            #func
+            #func_tokens
         }
     }
 }


### PR DESCRIPTION
The expansion of thrust_macros::{ensures, requires} remains mostly the same, but there’s a lot of plumbing involved to make this work. While the previous annotation mechanism directly attached attributes to the target def, thrust_macros::{ensures, requires} attaches annotations via extern_spec_fn. This made it difficult to fetch annotations using extract_{require, ensure}_annot. Instead, this PR’s implementation relies on def_ty_with_args to fetch the expected type of the trait method, which is given as an individual entry of defs (the previous implementation didn’t define the type of definition-side trait methods simply because they don’t have a body). See individual commits for details.