### PR TITLE
Specify spec of PartialEq and PartialOrd on trait method side for now

### DIFF
--- a/std.rs
+++ b/std.rs
@@ -617,3 +617,33 @@ fn _extern_spec_vec_is_empty<T>(vec: &Vec<T>) -> bool where T: thrust_models::Mo
 fn _extern_spec_vec_truncate<T>(vec: &mut Vec<T>, len: usize) where T: thrust_models::Model, T::Ty: PartialEq {
     Vec::truncate(vec, len)
 }
+
+// TODO: The following specs of some trait methods are too restrictive; we should allow for a
+//       per-impl spec once we can describe the spec of blanket impls.
+
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(result == (*x == *y))]
+fn _extern_spec_partialeq_eq<T>(x: &T, y: &T) -> bool
+  where T: thrust_models::Model + PartialEq, T::Ty: PartialEq
+{
+    PartialEq::eq(x, y)
+}
+
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(result == (*x < *y))]
+fn _extern_spec_partialord_lt<T>(x: &T, y: &T) -> bool
+  where T: thrust_models::Model + PartialOrd, T::Ty: PartialOrd
+{
+    PartialOrd::lt(x, y)
+}
+
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(result == (*x > *y))]
+fn _extern_spec_partialord_gt<T>(x: &T, y: &T) -> bool
+  where T: thrust_models::Model + PartialOrd, T::Ty: PartialOrd
+{
+    PartialOrd::gt(x, y)
+}

--- a/tests/ui/fail/fn_poly_ref_ord.rs
+++ b/tests/ui/fail/fn_poly_ref_ord.rs
@@ -1,0 +1,9 @@
+//@error-in-other-file: Unsat
+
+fn lt<T>(x: &T, y: &T) -> bool where T: Ord {
+    x < y
+}
+
+fn main() {
+    assert!(lt(&1, &0));
+}

--- a/tests/ui/pass/fn_poly_ref_ord.rs
+++ b/tests/ui/pass/fn_poly_ref_ord.rs
@@ -1,0 +1,9 @@
+//@check-pass
+
+fn lt<T>(x: &T, y: &T) -> bool where T: Ord {
+    x < y
+}
+
+fn main() {
+    assert!(lt(&1, &2));
+}


### PR DESCRIPTION
Sometimes rustc generates PartialEq and PartialOrd method calls like `<&i32 as PartialEq>::eq`. Since Thrust doesn't know how to type the DefId of `impl<T> PartialEq for &T`, it causes an "unknown def" panic. We should be able to handle these kinds of blanket impls, but it'll take some effort; we need to refer to the spec of `<T as PartialEq>::eq` within the spec of `<&T as PartialEq>::eq`, which isn't possible with the current annotation implementation. 

For now, this PR defines a simple PartialEq and PartialOrd specs applied for all implementors (as of #79) and leaves precise specs for blanket impls as future work.