### PR TITLE
Update toolchain to nightly-2025-09-08

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-03-08"
+channel = "nightly-2025-09-08"
 components = [ "rustc-dev", "rust-src", "llvm-tools-preview", "rust-analyzer" ]

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -37,7 +37,7 @@ pub use did_cache::DefIdCache;
 pub fn mir_borrowck_skip_formula_fn(
     tcx: rustc_middle::ty::TyCtxt<'_>,
     local_def_id: rustc_span::def_id::LocalDefId,
-) -> rustc_middle::query::queries::mir_borrowck::ProvidedValue {
+) -> rustc_middle::query::queries::mir_borrowck::ProvidedValue<'_> {
     // TODO: unify impl with local_def::Analyzer
     // if the def is closure defined in formula_fn
     let root_def_id = tcx.typeck_root_def_id(local_def_id.to_def_id());
@@ -52,13 +52,8 @@ pub fn mir_borrowck_skip_formula_fn(
 
     if is_annotated_as_formula_fn {
         tracing::debug!(?local_def_id, "skipping borrow check for formula fn");
-        let dummy_result = rustc_middle::mir::BorrowCheckResult {
-            concrete_opaque_types: Default::default(),
-            closure_requirements: None,
-            used_mut_upvars: Default::default(),
-            tainted_by_errors: None,
-        };
-        return tcx.arena.alloc(dummy_result);
+        let dummy_result = rustc_middle::mir::ConcreteOpaqueTypes(Default::default());
+        return Ok(tcx.arena.alloc(dummy_result));
     }
 
     (rustc_interface::DEFAULT_QUERY_PROVIDERS
@@ -511,7 +506,9 @@ impl<'tcx> Analyzer<'tcx> {
             let ret = rty::RefinedType::new(rty::Type::never(), rty::Refinement::bottom());
             rty::FunctionType::new([param.vacuous()].into_iter().collect(), ret)
         };
-        let panic_def_id = self.tcx.require_lang_item(LangItem::Panic, None);
+        let panic_def_id = self
+            .tcx
+            .require_lang_item(LangItem::Panic, rustc_span::DUMMY_SP);
         self.register_def(panic_def_id, rty::RefinedType::unrefined(panic_ty.into()));
     }
 
@@ -581,15 +578,15 @@ impl<'tcx> Analyzer<'tcx> {
         local_def_id: LocalDefId,
         attr_path: &[Symbol],
     ) -> Option<DefId> {
-        let map = self.tcx.hir();
         let body = self.tcx.hir_maybe_body_owned_by(local_def_id)?;
 
         let rustc_hir::ExprKind::Block(block, _) = body.value.kind else {
             return None;
         };
         for stmt in block.stmts {
-            if map
-                .attrs(stmt.hir_id)
+            if self
+                .tcx
+                .hir_attrs(stmt.hir_id)
                 .iter()
                 .all(|attr| !attr.path_matches(attr_path))
             {
@@ -724,7 +721,8 @@ impl<'tcx> Analyzer<'tcx> {
     /// Whether the given `def_id` corresponds to a method of one of the `Fn` traits.
     fn is_fn_trait_method(&self, def_id: DefId) -> bool {
         self.tcx
-            .trait_of_item(def_id)
+            .opt_associated_item(def_id)
+            .and_then(|item| item.trait_container(self.tcx))
             .and_then(|trait_did| self.tcx.fn_trait_kind_from_def_id(trait_did))
             .is_some()
     }

--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -233,7 +233,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
     }
 
-    fn const_value_ty(&self, val: &mir::ConstValue<'tcx>, ty: &mir_ty::Ty<'tcx>) -> PlaceType {
+    fn const_value_ty(&self, val: &mir::ConstValue, ty: &mir_ty::Ty<'tcx>) -> PlaceType {
         use mir::{interpret::Scalar, ConstValue, Mutability};
         match (ty.kind(), val) {
             (
@@ -262,9 +262,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                 mir_ty::TyKind::Ref(_, elem, Mutability::Not),
                 ConstValue::Scalar(Scalar::Ptr(ptr, _)),
             ) => {
-                // Pointer::into_parts is OK for CtfeProvenance
-                // in a later version of rustc it has prov_and_relative_offset that ensures this
-                let (prov, offset) = ptr.into_parts();
+                let (prov, offset) = ptr.prov_and_relative_offset();
                 let global_alloc = self.tcx.global_alloc(prov.alloc_id());
                 match global_alloc {
                     mir::interpret::GlobalAlloc::Memory(alloc) => {
@@ -281,9 +279,16 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                     _ => unimplemented!("const ptr alloc: {:?}", global_alloc),
                 }
             }
-            (mir_ty::TyKind::Ref(_, elem, Mutability::Not), ConstValue::Slice { data, meta }) => {
+            (
+                mir_ty::TyKind::Ref(_, elem, Mutability::Not),
+                ConstValue::Slice { alloc_id, meta },
+            ) => {
                 let end = (*meta).try_into().unwrap();
-                self.const_bytes_ty(*elem, *data, 0..end).immut()
+                let global_alloc = self.tcx.global_alloc(*alloc_id);
+                let mir::interpret::GlobalAlloc::Memory(alloc) = global_alloc else {
+                    unimplemented!("const slice alloc: {:?}", global_alloc);
+                };
+                self.const_bytes_ty(*elem, alloc, 0..end).immut()
             }
             _ => unimplemented!("const: {:?}, ty: {:?}", val, ty),
         }

--- a/src/analyze/did_cache.rs
+++ b/src/analyze/did_cache.rs
@@ -87,9 +87,9 @@ impl<'tcx> DefIdCache<'tcx> {
             }
 
             let item = self.tcx.hir_item(item_id);
-            if let rustc_hir::ItemKind::Trait(_, _, _, _, trait_item_refs) = item.kind {
+            if let rustc_hir::ItemKind::Trait(_, _, _, _, _, _, trait_item_refs) = item.kind {
                 for trait_item_ref in trait_item_refs {
-                    let def_id = trait_item_ref.id.owner_id.to_def_id();
+                    let def_id = trait_item_ref.owner_id.to_def_id();
                     if self.tcx.get_attrs_by_path(def_id, path).next().is_some() {
                         return Some(def_id);
                     }
@@ -97,7 +97,7 @@ impl<'tcx> DefIdCache<'tcx> {
             }
             if let rustc_hir::ItemKind::Impl(impl_) = item.kind {
                 for impl_item_ref in impl_.items {
-                    let def_id = impl_item_ref.id.owner_id.to_def_id();
+                    let def_id = impl_item_ref.owner_id.to_def_id();
                     if self.tcx.get_attrs_by_path(def_id, path).next().is_some() {
                         return Some(def_id);
                     }

--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -156,9 +156,14 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         // names and sorts of arguments
         let arg_names = self
             .tcx
-            .fn_arg_names(self.local_def_id.to_def_id())
+            .fn_arg_idents(self.local_def_id.to_def_id())
             .iter()
-            .map(|ident| ident.to_string());
+            .map(|ident| {
+                ident
+                    .expect("predicate arguments must be named")
+                    .name
+                    .to_string()
+            });
 
         let sig = self.ctx.fn_sig(self.local_def_id.to_def_id());
         let arg_sorts = sig
@@ -276,10 +281,10 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             .next()
             .is_some();
 
-        let arg_names = self.tcx.fn_arg_names(self.local_def_id.to_def_id());
+        let arg_names = self.tcx.fn_arg_idents(self.local_def_id.to_def_id());
         let all_params_annotated = arg_names
             .iter()
-            .all(|ident| annotated_params.contains(ident));
+            .all(|ident| ident.is_some_and(|i| annotated_params.contains(&i)));
         self.is_annotated_as_callable()
             || (has_requires && has_ensures)
             || (all_params_annotated && has_ret)
@@ -328,12 +333,17 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         let mut param_resolver = analyze::annot::ParamResolver::default();
         for (input_ident, input_ty) in self
             .tcx
-            .fn_arg_names(self.local_def_id.to_def_id())
+            .fn_arg_idents(self.local_def_id.to_def_id())
             .iter()
             .zip(sig.inputs())
         {
             let input_ty = self.type_builder.build(*input_ty);
-            param_resolver.push_param(input_ident.name, input_ty.to_sort());
+            param_resolver.push_param(
+                input_ident
+                    .map(|i| i.name)
+                    .unwrap_or(rustc_span::Symbol::intern("")),
+                input_ty.to_sort(),
+            );
         }
 
         let output_ty = self.type_builder.build(sig.output());

--- a/src/annot.rs
+++ b/src/annot.rs
@@ -330,7 +330,7 @@ where
         if t.kind == expected {
             Ok(())
         } else {
-            Err(ParseAttrError::unexpected_token(expected_str, t.clone()))
+            Err(ParseAttrError::unexpected_token(expected_str, *t))
         }
     }
 
@@ -339,7 +339,7 @@ where
         if let Some((ident, _)) = t.ident() {
             Ok(ident)
         } else {
-            Err(ParseAttrError::unexpected_token("ident", t.clone()))
+            Err(ParseAttrError::unexpected_token("ident", *t))
         }
     }
 
@@ -418,7 +418,7 @@ where
                     if segments.is_empty() {
                         return Err(ParseAttrError::unexpected_token(
                             "path segment before <",
-                            t.clone(),
+                            *t,
                         ));
                     }
                     let mut generic_args = Vec::new();
@@ -434,7 +434,7 @@ where
                                 kind: TokenKind::Gt,
                                 ..
                             } => break,
-                            t => return Err(ParseAttrError::unexpected_token(", or >", t.clone())),
+                            t => return Err(ParseAttrError::unexpected_token(", or >", *t)),
                         }
                     }
                     segments.last_mut().unwrap().generic_args = generic_args;
@@ -449,7 +449,7 @@ where
                         generic_args: Vec::new(),
                     });
                 }
-                t => return Err(ParseAttrError::unexpected_token("ident or <", t.clone())),
+                t => return Err(ParseAttrError::unexpected_token("ident or <", *t)),
             }
         }
         Ok(AnnotPath { segments })
@@ -623,13 +623,13 @@ where
                             self.expect_next_token(TokenKind::Gt, ">")?;
                             FormulaOrTerm::Term(chc::Term::mut_(t1, t2), chc::Sort::mut_(s1))
                         }
-                        t => return Err(ParseAttrError::unexpected_token("> or ,", t.clone())),
+                        t => return Err(ParseAttrError::unexpected_token("> or ,", *t)),
                     }
                 }
                 _ => {
                     return Err(ParseAttrError::unexpected_token(
                         "identifier, or literal",
-                        t.clone(),
+                        *t,
                     ));
                 }
             }
@@ -654,7 +654,7 @@ where
         }) = self.look_ahead_token(0)
         {
             self.consume();
-            let t = self.next_token("field")?.clone();
+            let t = *self.next_token("field")?;
             if let Token {
                 kind: TokenKind::Literal(lit),
                 ..
@@ -694,7 +694,7 @@ where
                     }
                 }
             }
-            return Err(ParseAttrError::unexpected_token("field", t.clone()));
+            return Err(ParseAttrError::unexpected_token("field", t));
         }
 
         if fields.is_empty() {
@@ -947,7 +947,7 @@ where
                             kind: TokenKind::Dot,
                             ..
                         } => break,
-                        t => return Err(ParseAttrError::unexpected_token(". or ,", t.clone())),
+                        t => return Err(ParseAttrError::unexpected_token(". or ,", *t)),
                     }
                 }
                 self.formula_existentials.extend(vars.iter().cloned());
@@ -1035,7 +1035,7 @@ where
                             parser.consume();
                         }
                         None => break,
-                        Some(t) => return Err(ParseAttrError::unexpected_token(",", t.clone())),
+                        Some(t) => return Err(ParseAttrError::unexpected_token(",", *t)),
                     }
                 }
                 parser.end_of_input()?;
@@ -1068,33 +1068,31 @@ where
                     }
                     s => {
                         let sym = chc::DatatypeSymbol::new(s.to_owned());
-                        let tys =
-                            if self.look_ahead_token(0).map(|t| &t.kind) == Some(&TokenKind::Lt) {
-                                self.consume();
-                                let mut tys = IndexVec::new();
-                                loop {
-                                    tys.push(self.parse_rty()?);
-                                    match self.next_token("> or ,")? {
-                                        Token {
-                                            kind: TokenKind::Comma,
-                                            ..
-                                        } => {}
-                                        Token {
-                                            kind: TokenKind::Gt,
-                                            ..
-                                        } => break,
-                                        t => {
-                                            return Err(ParseAttrError::unexpected_token(
-                                                ">, or ,",
-                                                t.clone(),
-                                            ))
-                                        }
+                        let tys = if self.look_ahead_token(0).map(|t| &t.kind)
+                            == Some(&TokenKind::Lt)
+                        {
+                            self.consume();
+                            let mut tys = IndexVec::new();
+                            loop {
+                                tys.push(self.parse_rty()?);
+                                match self.next_token("> or ,")? {
+                                    Token {
+                                        kind: TokenKind::Comma,
+                                        ..
+                                    } => {}
+                                    Token {
+                                        kind: TokenKind::Gt,
+                                        ..
+                                    } => break,
+                                    t => {
+                                        return Err(ParseAttrError::unexpected_token(">, or ,", *t))
                                     }
                                 }
-                                tys
-                            } else {
-                                Default::default()
-                            };
+                            }
+                            tys
+                        } else {
+                            Default::default()
+                        };
                         rty::EnumType::new(sym, tys).into()
                     }
                 };
@@ -1142,7 +1140,7 @@ where
                             parser.consume();
                         }
                         None => break,
-                        Some(t) => return Err(ParseAttrError::unexpected_token(",", t.clone())),
+                        Some(t) => return Err(ParseAttrError::unexpected_token(",", *t)),
                     }
                 }
                 parser.end_of_input()?;
@@ -1177,7 +1175,7 @@ where
         ) {
             let h = parser.next_token("ident")?;
             let Some((ident, _)) = h.ident() else {
-                return Err(ParseAttrError::unexpected_token("ident", h.clone()));
+                return Err(ParseAttrError::unexpected_token("ident", *h));
             };
             parser.consume();
             Some(ident)

--- a/src/chc/debug.rs
+++ b/src/chc/debug.rs
@@ -119,7 +119,7 @@ impl DebugInfo {
         self
     }
 
-    pub fn display(&self, line_head: &'static str) -> Display {
+    pub fn display(&self, line_head: &'static str) -> Display<'_> {
         Display {
             inner: self,
             line_head,

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -72,19 +72,19 @@ where
 #[allow(dead_code)]
 pub trait PrettySliceExt {
     type Item;
-    fn pretty_slice(&self) -> PrettySlice<Self::Item>;
+    fn pretty_slice(&self) -> PrettySlice<'_, Self::Item>;
 }
 
 impl<T> PrettySliceExt for [T] {
     type Item = T;
-    fn pretty_slice(&self) -> PrettySlice<T> {
+    fn pretty_slice(&self) -> PrettySlice<'_, T> {
         PrettySlice { slice: self }
     }
 }
 
 impl<T> PrettySliceExt for Vec<T> {
     type Item = T;
-    fn pretty_slice(&self) -> PrettySlice<T> {
+    fn pretty_slice(&self) -> PrettySlice<'_, T> {
         PrettySlice {
             slice: self.as_slice(),
         }
@@ -93,14 +93,14 @@ impl<T> PrettySliceExt for Vec<T> {
 
 impl<I: rustc_index::Idx, T> PrettySliceExt for IndexSlice<I, T> {
     type Item = T;
-    fn pretty_slice(&self) -> PrettySlice<T> {
+    fn pretty_slice(&self) -> PrettySlice<'_, T> {
         PrettySlice { slice: &self.raw }
     }
 }
 
 impl<I: rustc_index::Idx, T> PrettySliceExt for IndexVec<I, T> {
     type Item = T;
-    fn pretty_slice(&self) -> PrettySlice<T> {
+    fn pretty_slice(&self) -> PrettySlice<'_, T> {
         PrettySlice {
             slice: self.raw.as_slice(),
         }
@@ -124,14 +124,14 @@ where
 }
 
 pub trait PrettyDisplayExt: Sized {
-    fn display(&self) -> Display<Self>;
+    fn display(&self) -> Display<'_, Self>;
 }
 
 impl<P> PrettyDisplayExt for P
 where
     for<'a, 'b> &'b P: Pretty<'a, pretty::Arena<'a, termcolor::ColorSpec>, termcolor::ColorSpec>,
 {
-    fn display(&self) -> Display<Self> {
+    fn display(&self) -> Display<'_, Self> {
         Display::new(self)
     }
 }

--- a/src/refine/template.rs
+++ b/src/refine/template.rs
@@ -126,14 +126,14 @@ impl<'tcx> TypeBuilder<'tcx> {
             closure_model_id: DefId,
         }
 
-        use mir_ty::fold::TypeFoldable;
-        impl<'tcx> mir_ty::fold::TypeFolder<mir_ty::TyCtxt<'tcx>> for ReplaceClosureModel<'tcx> {
+        use mir_ty::TypeFoldable;
+        impl<'tcx> mir_ty::TypeFolder<mir_ty::TyCtxt<'tcx>> for ReplaceClosureModel<'tcx> {
             fn cx(&self) -> mir_ty::TyCtxt<'tcx> {
                 self.tcx
             }
 
             fn fold_ty(&mut self, ty: mir_ty::Ty<'tcx>) -> mir_ty::Ty<'tcx> {
-                use mir_ty::fold::TypeSuperFoldable;
+                use mir_ty::TypeSuperFoldable;
                 if let mir_ty::TyKind::Closure(_, args) = ty.kind() {
                     let args = self
                         .tcx

--- a/tests/ui/fail/enum_ref_drop.rs
+++ b/tests/ui/fail/enum_ref_drop.rs
@@ -1,5 +1,6 @@
 //@error-in-other-file: Unsat
 //@compile-flags: -C debug-assertions=off
+//@no-rustfix
 
 pub enum X<'a, 'b> {
     A(&'a mut i64),


### PR DESCRIPTION
#26 

API changes in nightly-2025-09-08:
- mir_borrowck now returns Result<&ConcreteOpaqueTypes, ErrorGuaranteed> instead of &BorrowCheckResult
- require_lang_item takes Span instead of Option<Span>
- tcx.hir().attrs(id) -> tcx.hir_attrs(id)
- tcx.trait_of_item() -> tcx.opt_associated_item().trait_container()
- ConstValue no longer has a lifetime parameter
- ConstValue::Slice { data } -> { alloc_id }; fetch alloc via global_alloc
- Pointer::into_parts() -> into_raw_parts() (returns (Prov, Size))
- ItemKind::Trait gained Safety and Ident fields (5 -> 7 fields)
- TraitItemId and ImplItemId lost the .id wrapper (use .owner_id directly)
- fn_arg_names() -> fn_arg_idents() returning &[Option<Ident>]
- mir_ty::fold::TypeFoldable/TypeFolder/TypeSuperFoldable are now re-exported at the top level as mir_ty::TypeFoldable etc.
- mismatched_lifetime_syntaxes lint generates invalid rustfix suggestion for enum_ref_drop test; disable rustfix with //@no-rustfix

https://claude.ai/code/session_01URrtbSTUKNrVKLK2MNLBFc