### PR TITLE
Eliminate per-basic-block postcondition predicate variables

### DIFF
--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -508,28 +508,70 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         self.type_rvalue(Rvalue::Use(operand), expected);
     }
 
-    fn type_return(&mut self, expected: &rty::RefinedType<Var>) {
-        self.type_operand(Operand::Move(mir::RETURN_PLACE.into()), expected);
+    fn type_return(
+        &mut self,
+        expected_fn: &rty::FunctionType,
+        outer_fn_param_vars: &HashMap<rty::FunctionParamIdx, Var>,
+    ) {
+        let mut builder = self.env.build_clause();
+        let mut clauses = Vec::new();
+
+        for (&param_idx, &param_var) in outer_fn_param_vars {
+            let sort = expected_fn.params[param_idx].ty.to_sort();
+            if sort.is_singleton() {
+                continue;
+            }
+            builder.add_mapped_var(param_idx, sort);
+            let tv_param_idx = builder.mapped_var(param_idx);
+            let tv_param_var = builder.mapped_var(param_var);
+            builder.add_body(chc::Term::var(tv_param_idx).equal_to(chc::Term::var(tv_param_var)));
+        }
+
+        let ret_rty = self.operand_refined_type(Operand::Move(mir::RETURN_PLACE.into()));
+
+        let cs = builder
+            .with_value_var(&expected_fn.ret.ty)
+            .add_body(ret_rty.refinement)
+            .head(expected_fn.ret.refinement.clone());
+        clauses.extend(cs);
+        clauses.extend(builder.relate_sub_type(&ret_rty.ty, &expected_fn.ret.ty));
+
+        self.ctx.extend_clauses(clauses);
     }
 
-    fn type_goto(&mut self, bb: BasicBlock, expected_ret: &rty::RefinedType<Var>) {
-        tracing::debug!(bb = ?bb, "type_goto");
+    fn type_goto(
+        &mut self,
+        bb: BasicBlock,
+        expected_ret: &rty::RefinedType<Var>,
+        outer_fn_param_vars: &HashMap<rty::FunctionParamIdx, Var>,
+    ) {
         let bty = self.basic_block_ty(bb);
         let expected_args: IndexVec<_, _> = bty
             .as_ref()
             .params
             .iter_enumerated()
             .map(|(param_idx, rty)| {
-                if let Some(arg_local) = bty.local_of_param(param_idx) {
-                    let arg_local_ty = self.env.local_type(arg_local);
-                    // TODO: should we cover "is_singleton" ness in relate_* methods or here?
-                    if !rty.ty.to_sort().is_singleton() {
-                        arg_local_ty.into()
-                    } else {
-                        rty::RefinedType::unrefined(arg_local_ty.ty)
+                match bty.param_kind(param_idx) {
+                    BasicBlockTypeParamKind::Local(arg_local, _) => {
+                        let arg_local_ty = self.env.local_type(arg_local);
+                        // TODO: should we cover "is_singleton" ness in relate_* methods or here?
+                        if !rty.ty.to_sort().is_singleton() {
+                            arg_local_ty.into()
+                        } else {
+                            rty::RefinedType::unrefined(arg_local_ty.ty)
+                        }
                     }
-                } else {
-                    rty::RefinedType::unrefined(rty.ty.clone().assert_closed().vacuous())
+                    BasicBlockTypeParamKind::OuterFnParam(outer_idx) => {
+                        let outer_fn_param_var = outer_fn_param_vars[&outer_idx];
+                        let pty = PlaceType::with_ty_and_term(
+                            rty.ty.clone().assert_closed().vacuous(),
+                            chc::Term::var(outer_fn_param_var),
+                        );
+                        pty.into()
+                    }
+                    BasicBlockTypeParamKind::Synthetic => {
+                        rty::RefinedType::unrefined(rty.ty.clone().assert_closed().vacuous())
+                    }
                 }
             })
             .collect();
@@ -565,6 +607,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         discr: Operand<'tcx>,
         targets: mir::SwitchTargets,
         expected_ret: &rty::RefinedType<Var>,
+        outer_fn_param_vars: &HashMap<rty::FunctionParamIdx, Var>,
         mut callback: F,
     ) where
         F: FnMut(&mut Self, BasicBlock),
@@ -588,7 +631,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             };
             self.with_assumption(pos_assumption, |ecx| {
                 callback(ecx, bb);
-                ecx.type_goto(bb, expected_ret);
+                ecx.type_goto(bb, expected_ret, outer_fn_param_vars);
             });
             let neg_assumption = {
                 let mut builder = PlaceTypeBuilder::default();
@@ -600,7 +643,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
         self.with_assumptions(negations, |ecx| {
             callback(ecx, targets.otherwise());
-            ecx.type_goto(targets.otherwise(), expected_ret);
+            ecx.type_goto(targets.otherwise(), expected_ret, outer_fn_param_vars);
         });
     }
 
@@ -877,26 +920,34 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
     }
 
-    #[tracing::instrument(skip(self, expected_ret), fields(term = ?term.kind))]
+    #[tracing::instrument(skip(self, expected_ret, expected_fn, outer_fn_param_vars), fields(term = ?term.kind))]
     fn analyze_terminator_goto(
         &mut self,
         term: &mir::Terminator<'tcx>,
         expected_ret: &rty::RefinedType<Var>,
+        expected_fn: &rty::FunctionType,
+        outer_fn_param_vars: &HashMap<rty::FunctionParamIdx, Var>,
     ) {
         match &term.kind {
             TerminatorKind::Return => {
-                self.type_return(expected_ret);
+                self.type_return(expected_fn, outer_fn_param_vars);
             }
             TerminatorKind::Goto { target } => {
-                self.type_goto(*target, expected_ret);
+                self.type_goto(*target, expected_ret, outer_fn_param_vars);
             }
             TerminatorKind::SwitchInt { discr, targets } => {
-                self.type_switch_int(discr.clone(), targets.clone(), expected_ret, |a, target| {
-                    for local in a.drop_points.after_terminator(&target).iter() {
-                        tracing::info!(?local, ?target, "implicitly dropped for target");
-                        a.drop_local(local);
-                    }
-                });
+                self.type_switch_int(
+                    discr.clone(),
+                    targets.clone(),
+                    expected_ret,
+                    outer_fn_param_vars,
+                    |a, target| {
+                        for local in a.drop_points.after_terminator(&target).iter() {
+                            tracing::info!(?local, ?target, "implicitly dropped for target");
+                            a.drop_local(local);
+                        }
+                    },
+                );
             }
             TerminatorKind::Call { target, .. } => {
                 if let Some(target) = target {
@@ -904,7 +955,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                         tracing::info!(?local, "implicitly dropped after call");
                         self.drop_local(local);
                     }
-                    self.type_goto(*target, expected_ret);
+                    self.type_goto(*target, expected_ret, outer_fn_param_vars);
                 }
             }
             TerminatorKind::Drop { target, .. } => {
@@ -912,7 +963,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                     tracing::info!(?local, "dropped");
                     self.drop_local(local);
                 }
-                self.type_goto(*target, expected_ret);
+                self.type_goto(*target, expected_ret, outer_fn_param_vars);
             }
             TerminatorKind::Assert {
                 cond,
@@ -931,7 +982,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                         chc::Term::bool(*expected),
                     ),
                 );
-                self.type_goto(*target, expected_ret);
+                self.type_goto(*target, expected_ret, outer_fn_param_vars);
             }
             TerminatorKind::UnwindResume {} => {}
             TerminatorKind::Unreachable {} => {}
@@ -1085,9 +1136,11 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     fn bind_locals(
         &mut self,
         expected_params: &IndexVec<rty::FunctionParamIdx, rty::RefinedType<rty::FunctionParamIdx>>,
-    ) {
+    ) -> HashMap<rty::FunctionParamIdx, Var> {
         let mut param_terms = HashMap::<rty::FunctionParamIdx, chc::Term<PlaceTypeVar>>::new();
         let mut assumption = Assumption::default();
+
+        let mut outer_fn_param_vars = HashMap::new();
 
         let bb_ty = self.basic_block_ty(self.basic_block).clone();
         let params = &bb_ty.as_ref().params;
@@ -1102,35 +1155,38 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                         _ => unimplemented!(),
                     })
                 }));
-            if let Some(local) = bb_ty.local_of_param(param_idx) {
-                if bb_ty.mutbl_of_param(param_idx).unwrap().is_mut()
-                    || param_unrefined_rty.ty.is_mut()
-                {
-                    self.env.mut_bind(local, param_unrefined_rty);
-                } else {
-                    self.env.immut_bind(local, param_unrefined_rty);
-                }
-                let param_sort = param_ty.to_sort();
-                if param_sort.is_singleton() {
-                    continue;
-                }
+            match bb_ty.param_kind(param_idx) {
+                BasicBlockTypeParamKind::Local(local, _) => {
+                    if bb_ty.mutbl_of_param(param_idx).unwrap().is_mut()
+                        || param_unrefined_rty.ty.is_mut()
+                    {
+                        self.env.mut_bind(local, param_unrefined_rty);
+                    } else {
+                        self.env.immut_bind(local, param_unrefined_rty);
+                    }
+                    let param_sort = param_ty.to_sort();
+                    if param_sort.is_singleton() {
+                        continue;
+                    }
 
-                let local_ty = self.env.local_type(local);
-                assumption.body.push_conj(
-                    local_ty
-                        .formula
-                        .map_var(|v| v.shift_existential(assumption.existentials.len())),
-                );
-                let term = local_ty
-                    .term
-                    .map_var(|v| v.shift_existential(assumption.existentials.len()));
-                assumption.existentials.extend(local_ty.existentials);
-                param_terms.insert(param_idx, term);
-            } else {
-                if !param_ty.to_sort().is_singleton() {
+                    let local_ty = self.env.local_type(local);
+                    assumption.body.push_conj(
+                        local_ty
+                            .formula
+                            .map_var(|v| v.shift_existential(assumption.existentials.len())),
+                    );
+                    let term = local_ty
+                        .term
+                        .map_var(|v| v.shift_existential(assumption.existentials.len()));
+                    assumption.existentials.extend(local_ty.existentials);
+                    param_terms.insert(param_idx, term);
+                }
+                BasicBlockTypeParamKind::OuterFnParam(outer_idx) => {
                     let var = self.env.immut_bind_tmp(param_unrefined_rty);
                     param_terms.insert(param_idx, chc::Term::var(var.into()));
+                    outer_fn_param_vars.insert(outer_idx, var);
                 }
+                BasicBlockTypeParamKind::Synthetic => {}
             }
         }
 
@@ -1147,6 +1203,8 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
 
         self.env.assume(assumption);
+
+        outer_fn_param_vars
     }
 
     fn unbind_atoms(&self) -> UnbindAtoms<rty::FunctionParamIdx> {
@@ -1212,13 +1270,13 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         self
     }
 
-    pub fn run(&mut self, expected: &BasicBlockType) {
+    pub fn run(&mut self, expected: &BasicBlockType, expected_fn: &rty::FunctionType) {
         let span = tracing::info_span!("bb", bb = ?self.basic_block);
         let _guard = span.enter();
         self.register_enum_defs();
 
         let params = expected.as_ref().params.clone();
-        self.bind_locals(&params);
+        let outer_fn_param_vars = self.bind_locals(&params);
         let unbind_atoms = self.unbind_atoms();
         self.alloc_prophecies();
         self.analyze_statements();
@@ -1226,7 +1284,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         let term = self.elaborated_terminator();
         self.analyze_terminator_binds(&term);
         let ret_template = self.ret_template();
-        self.analyze_terminator_goto(&term, &ret_template);
+        self.analyze_terminator_goto(&term, &ret_template, expected_fn, &outer_fn_param_vars);
 
         let got_ret_ty = unbind_atoms.unbind(&self.env, ret_template);
         let got_ty = rty::FunctionType::new(params, got_ret_ty).into_closed_ty();

--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -87,7 +87,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     fn relate_fn_sub_type(
         &mut self,
         got: rty::FunctionType,
-        mut expected_args: IndexVec<rty::FunctionParamIdx, rty::RefinedType<Var>>,
+        expected_args: IndexVec<rty::FunctionParamIdx, rty::RefinedType<Var>>,
         expected_ret: rty::RefinedType<Var>,
     ) -> Vec<chc::Clause> {
         let mut clauses = Vec::new();
@@ -98,7 +98,49 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             "fn_sub_type"
         );
 
-        match got.abi {
+        let mut builder = self.env.build_clause();
+        let cs = self.relate_fn_param_sub_types_with_builder(
+            got.params,
+            expected_args,
+            &mut builder,
+            got.abi,
+        );
+        clauses.extend(cs);
+
+        let cs = builder
+            .with_value_var(&got.ret.ty)
+            .add_body(got.ret.refinement)
+            .head(expected_ret.refinement);
+        clauses.extend(cs);
+
+        clauses.extend(builder.relate_sub_type(&got.ret.ty, &expected_ret.ty));
+        clauses
+    }
+
+    fn relate_fn_param_sub_types(
+        &mut self,
+        got_args: IndexVec<rty::FunctionParamIdx, rty::RefinedType<rty::FunctionParamIdx>>,
+        expected_args: IndexVec<rty::FunctionParamIdx, rty::RefinedType<Var>>,
+    ) -> Vec<chc::Clause> {
+        let mut builder = self.env.build_clause();
+        self.relate_fn_param_sub_types_with_builder(
+            got_args,
+            expected_args,
+            &mut builder,
+            rty::FunctionAbi::Rust,
+        )
+    }
+
+    fn relate_fn_param_sub_types_with_builder(
+        &mut self,
+        got_args: IndexVec<rty::FunctionParamIdx, rty::RefinedType<rty::FunctionParamIdx>>,
+        mut expected_args: IndexVec<rty::FunctionParamIdx, rty::RefinedType<Var>>,
+        builder: &mut chc::ClauseBuilder,
+        abi: rty::FunctionAbi,
+    ) -> Vec<chc::Clause> {
+        let mut clauses = Vec::new();
+
+        match abi {
             rty::FunctionAbi::Rust => {
                 if expected_args.is_empty() {
                     // elaboration: we need at least one predicate variable in parameter (see mir_function_ty_impl)
@@ -135,21 +177,21 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                 }
 
                 tracing::info!(
-                    expected = %crate::pretty::FunctionType::new(&expected_args, &expected_ret).display(),
+                    expected = %crate::pretty::FunctionParams::new(&expected_args).display(),
                     "rust-call expanded",
                 );
             }
         }
 
-        // TODO: check sty and length is equal
-        let mut builder = self.env.build_clause();
-        for (param_idx, param_rty) in got.params.iter_enumerated() {
+        assert!(got_args.len() == expected_args.len());
+        // TODO: check stys are equal
+        for (param_idx, param_rty) in got_args.iter_enumerated() {
             let param_sort = param_rty.ty.to_sort();
             if !param_sort.is_singleton() {
                 builder.add_mapped_var(param_idx, param_sort);
             }
         }
-        for ((param_idx, got_ty), expected_ty) in got.params.iter_enumerated().zip(&expected_args) {
+        for ((param_idx, got_ty), expected_ty) in got_args.iter_enumerated().zip(&expected_args) {
             // TODO we can use relate_sub_refined_type here when we implemenented builder-aware relate_*
             let cs = builder
                 .clone()
@@ -163,12 +205,6 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             clauses.extend(builder.relate_sub_type(&expected_ty.ty, &got_ty.ty));
         }
 
-        let cs = builder
-            .with_value_var(&got.ret.ty)
-            .add_body(got.ret.refinement)
-            .head(expected_ret.refinement);
-        clauses.extend(cs);
-        clauses.extend(builder.relate_sub_type(&got.ret.ty, &expected_ret.ty));
         clauses
     }
 
@@ -542,7 +578,6 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     fn type_goto(
         &mut self,
         bb: BasicBlock,
-        expected_ret: &rty::RefinedType<Var>,
         outer_fn_param_vars: &HashMap<rty::FunctionParamIdx, Var>,
     ) {
         let bty = self.basic_block_ty(bb);
@@ -575,8 +610,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                 }
             })
             .collect();
-        let clauses =
-            self.relate_fn_sub_type(bty.to_function_ty(), expected_args, expected_ret.clone());
+        let clauses = self.relate_fn_param_sub_types(bty.as_ref().params.clone(), expected_args);
         self.ctx.extend_clauses(clauses);
     }
 
@@ -606,7 +640,6 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         &mut self,
         discr: Operand<'tcx>,
         targets: mir::SwitchTargets,
-        expected_ret: &rty::RefinedType<Var>,
         outer_fn_param_vars: &HashMap<rty::FunctionParamIdx, Var>,
         mut callback: F,
     ) where
@@ -631,7 +664,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             };
             self.with_assumption(pos_assumption, |ecx| {
                 callback(ecx, bb);
-                ecx.type_goto(bb, expected_ret, outer_fn_param_vars);
+                ecx.type_goto(bb, outer_fn_param_vars);
             });
             let neg_assumption = {
                 let mut builder = PlaceTypeBuilder::default();
@@ -643,7 +676,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
         self.with_assumptions(negations, |ecx| {
             callback(ecx, targets.otherwise());
-            ecx.type_goto(targets.otherwise(), expected_ret, outer_fn_param_vars);
+            ecx.type_goto(targets.otherwise(), outer_fn_param_vars);
         });
     }
 
@@ -920,11 +953,10 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
     }
 
-    #[tracing::instrument(skip(self, expected_ret, expected_fn, outer_fn_param_vars), fields(term = ?term.kind))]
+    #[tracing::instrument(skip(self, expected_fn, outer_fn_param_vars), fields(term = ?term.kind))]
     fn analyze_terminator_goto(
         &mut self,
         term: &mir::Terminator<'tcx>,
-        expected_ret: &rty::RefinedType<Var>,
         expected_fn: &rty::FunctionType,
         outer_fn_param_vars: &HashMap<rty::FunctionParamIdx, Var>,
     ) {
@@ -933,13 +965,12 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                 self.type_return(expected_fn, outer_fn_param_vars);
             }
             TerminatorKind::Goto { target } => {
-                self.type_goto(*target, expected_ret, outer_fn_param_vars);
+                self.type_goto(*target, outer_fn_param_vars);
             }
             TerminatorKind::SwitchInt { discr, targets } => {
                 self.type_switch_int(
                     discr.clone(),
                     targets.clone(),
-                    expected_ret,
                     outer_fn_param_vars,
                     |a, target| {
                         for local in a.drop_points.after_terminator(&target).iter() {
@@ -955,7 +986,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                         tracing::info!(?local, "implicitly dropped after call");
                         self.drop_local(local);
                     }
-                    self.type_goto(*target, expected_ret, outer_fn_param_vars);
+                    self.type_goto(*target, outer_fn_param_vars);
                 }
             }
             TerminatorKind::Drop { target, .. } => {
@@ -963,7 +994,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                     tracing::info!(?local, "dropped");
                     self.drop_local(local);
                 }
-                self.type_goto(*target, expected_ret, outer_fn_param_vars);
+                self.type_goto(*target, outer_fn_param_vars);
             }
             TerminatorKind::Assert {
                 cond,
@@ -982,7 +1013,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                         chc::Term::bool(*expected),
                     ),
                 );
-                self.type_goto(*target, expected_ret, outer_fn_param_vars);
+                self.type_goto(*target, outer_fn_param_vars);
             }
             TerminatorKind::UnwindResume {} => {}
             TerminatorKind::Unreachable {} => {}
@@ -1275,22 +1306,12 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         let _guard = span.enter();
         self.register_enum_defs();
 
-        let params = expected.as_ref().params.clone();
-        let outer_fn_param_vars = self.bind_locals(&params);
-        let unbind_atoms = self.unbind_atoms();
+        let outer_fn_param_vars = self.bind_locals(&expected.as_ref().params);
         self.alloc_prophecies();
         self.analyze_statements();
 
         let term = self.elaborated_terminator();
         self.analyze_terminator_binds(&term);
-        let ret_template = self.ret_template();
-        self.analyze_terminator_goto(&term, &ret_template, expected_fn, &outer_fn_param_vars);
-
-        let got_ret_ty = unbind_atoms.unbind(&self.env, ret_template);
-        let got_ty = rty::FunctionType::new(params, got_ret_ty).into_closed_ty();
-        let clauses = self
-            .env
-            .relate_sub_type(&got_ty, &expected.to_function_ty().into_closed_ty());
-        self.ctx.extend_clauses(clauses);
+        self.analyze_terminator_goto(&term, expected_fn, &outer_fn_param_vars);
     }
 }

--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -1021,15 +1021,6 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    fn ret_template(&mut self) -> rty::RefinedType<Var> {
-        let ret_ty = self.body.local_decls[mir::RETURN_PLACE].ty;
-        self.type_builder
-            .for_template(&mut self.ctx)
-            .with_scope(&self.env)
-            .build_refined(ret_ty)
-    }
-
     // TODO: remove this
     fn alloc_prophecies(&mut self) {
         for (stmt_idx, stmt) in self.body.basic_blocks[self.basic_block]
@@ -1073,92 +1064,6 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                 self.ctx.get_or_register_enum_def(def_id);
             }
         }
-    }
-}
-
-/// Turns [`rty::RefinedType<Var>`] into [`rty::RefinedType<T>`].
-///
-/// We sometimes need to replace [`rty::RefinedTypeVar<Var>`] with [`rty::RefinedTypeVar<T>`].
-/// In [`analyze::basic_block`] module, `T` is [`rty::FunctionParamIdx`]. The type we get as
-/// a function result is obtained as [`rty::RefinedTypeVar<Var>`], but we need to express it using
-/// only function parameters for the subtyping. [`UnbindAtoms`] holds the relation between
-/// the function parameters and their representaion under the environment and
-/// let the type in environment be expressed only under the function parameters using existentials.
-#[derive(Debug, Clone)]
-pub struct UnbindAtoms<T> {
-    existentials: IndexVec<rty::ExistentialVarIdx, chc::Sort>,
-    body: chc::Body<rty::RefinedTypeVar<Var>>,
-    target_equations: Vec<(rty::RefinedTypeVar<T>, chc::Term<rty::RefinedTypeVar<Var>>)>,
-}
-
-impl<T> Default for UnbindAtoms<T> {
-    fn default() -> Self {
-        UnbindAtoms {
-            existentials: Default::default(),
-            body: Default::default(),
-            target_equations: Default::default(),
-        }
-    }
-}
-
-impl<T> UnbindAtoms<T> {
-    pub fn push(&mut self, target: rty::RefinedTypeVar<T>, var_ty: PlaceType) {
-        self.body.push_conj(
-            var_ty
-                .formula
-                .map_var(|v| v.shift_existential(self.existentials.len()).into()),
-        );
-        self.target_equations.push((
-            target,
-            var_ty
-                .term
-                .map_var(|v| v.shift_existential(self.existentials.len()).into()),
-        ));
-        self.existentials.extend(var_ty.existentials);
-    }
-
-    pub fn unbind(mut self, env: &analyze::Env, ty: rty::RefinedType<Var>) -> rty::RefinedType<T> {
-        let rty::RefinedType {
-            ty: src_ty,
-            refinement,
-        } = ty;
-        let rty::Refinement { existentials, body } = refinement;
-
-        self.body
-            .push_conj(body.map_var(|v| v.shift_existential(self.existentials.len())));
-        self.existentials.extend(existentials);
-
-        let mut substs = HashMap::new();
-        for (v, sort) in env.dependencies() {
-            let ev = self.existentials.push(sort);
-            substs.insert(v, ev);
-        }
-
-        let mut body = self.body.map_var(|v| match v {
-            rty::RefinedTypeVar::Value => rty::RefinedTypeVar::Value,
-            rty::RefinedTypeVar::Free(v) => rty::RefinedTypeVar::Existential(substs[&v]),
-            rty::RefinedTypeVar::Existential(ev) => rty::RefinedTypeVar::Existential(ev),
-        });
-        body.push_conj(
-            self.target_equations
-                .into_iter()
-                .map(|(t, term)| {
-                    chc::Term::var(t).equal_to(term.map_var(|v| match v {
-                        rty::RefinedTypeVar::Value => rty::RefinedTypeVar::Value,
-                        rty::RefinedTypeVar::Free(v) => {
-                            rty::RefinedTypeVar::Existential(substs[&v])
-                        }
-                        rty::RefinedTypeVar::Existential(ev) => {
-                            rty::RefinedTypeVar::Existential(ev)
-                        }
-                    }))
-                })
-                .collect::<Vec<_>>(),
-        );
-
-        let refinement = rty::Refinement::new(self.existentials, body);
-        // TODO: polymorphic datatypes: template needed?
-        rty::RefinedType::new(src_ty.assert_closed().vacuous(), refinement)
     }
 }
 
@@ -1236,25 +1141,6 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         self.env.assume(assumption);
 
         outer_fn_param_vars
-    }
-
-    fn unbind_atoms(&self) -> UnbindAtoms<rty::FunctionParamIdx> {
-        let bb_ty = self.basic_block_ty(self.basic_block);
-        let mut atoms = UnbindAtoms::default();
-        if self.is_defined(mir::RETURN_PLACE) && !bb_ty.as_ref().ret.ty.to_sort().is_singleton() {
-            let r_ty = self.operand_type(Operand::Move(mir::RETURN_PLACE.into()));
-            atoms.push(rty::RefinedTypeVar::Value, r_ty);
-        }
-        for (param_idx, param_ty) in bb_ty.as_ref().params.iter_enumerated() {
-            if param_ty.ty.to_sort().is_singleton() {
-                continue;
-            }
-            if let Some(local) = bb_ty.local_of_param(param_idx) {
-                let local_ty = self.env.local_type(local);
-                atoms.push(rty::RefinedTypeVar::Free(param_idx), local_ty);
-            }
-        }
-        atoms
     }
 }
 

--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -13,8 +13,8 @@ use crate::analyze;
 use crate::chc;
 use crate::pretty::PrettyDisplayExt as _;
 use crate::refine::{
-    Assumption, BasicBlockType, PlaceType, PlaceTypeBuilder, PlaceTypeVar, TempVarIdx, TypeBuilder,
-    Var,
+    Assumption, BasicBlockType, BasicBlockTypeParamKind, PlaceType, PlaceTypeBuilder, PlaceTypeVar,
+    TempVarIdx, TypeBuilder, Var,
 };
 use crate::rty::{
     self, ClauseBuilderExt as _, ClauseScope as _, ShiftExistential as _, Subtyping as _,
@@ -1094,18 +1094,21 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         assert!(!params.is_empty());
         for (param_idx, param_rty) in params.iter_enumerated() {
             let param_ty = &param_rty.ty;
-            if let Some(local) = bb_ty.local_of_param(param_idx) {
-                let rty = rty::RefinedType::unrefined(param_ty.clone().subst_var(|v| {
+            let param_unrefined_rty =
+                rty::RefinedType::unrefined(param_ty.clone().subst_var(|v| {
                     param_terms[&v].clone().map_var(|v| match v {
                         PlaceTypeVar::Var(v) => v,
                         // TODO
                         _ => unimplemented!(),
                     })
                 }));
-                if bb_ty.mutbl_of_param(param_idx).unwrap().is_mut() || rty.ty.is_mut() {
-                    self.env.mut_bind(local, rty);
+            if let Some(local) = bb_ty.local_of_param(param_idx) {
+                if bb_ty.mutbl_of_param(param_idx).unwrap().is_mut()
+                    || param_unrefined_rty.ty.is_mut()
+                {
+                    self.env.mut_bind(local, param_unrefined_rty);
                 } else {
-                    self.env.immut_bind(local, rty);
+                    self.env.immut_bind(local, param_unrefined_rty);
                 }
                 let param_sort = param_ty.to_sort();
                 if param_sort.is_singleton() {
@@ -1123,6 +1126,11 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                     .map_var(|v| v.shift_existential(assumption.existentials.len()));
                 assumption.existentials.extend(local_ty.existentials);
                 param_terms.insert(param_idx, term);
+            } else {
+                if !param_ty.to_sort().is_singleton() {
+                    let var = self.env.immut_bind_tmp(param_unrefined_rty);
+                    param_terms.insert(param_idx, chc::Term::var(var.into()));
+                }
             }
         }
 

--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -859,7 +859,8 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
     }
 
-    fn analyze_basic_blocks(&mut self) {
+    fn analyze_basic_blocks(&mut self, expected_fn_ty: &rty::RefinedType) {
+        let expected_fn_ty = expected_fn_ty.ty.as_function().unwrap();
         for bb in self.body.basic_blocks.indices() {
             let rty = self.ctx.basic_block_ty(self.local_def_id, bb).clone();
             let drop_points = self.drop_points[&bb].clone();
@@ -867,7 +868,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                 .basic_block_analyzer(self.local_def_id, bb)
                 .body(self.body.clone())
                 .drop_points(drop_points)
-                .run(&rty);
+                .run(&rty, expected_fn_ty);
         }
     }
 
@@ -982,7 +983,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         let entry_ty = self.drop_bb_zst_params(&entry_ty);
 
         tracing::debug!(expected = %expected.display(), entry = %entry_ty.display(), "assert_entry after");
-        let clauses = rty::relate_sub_closed_type(&entry_ty.into(), &expected.into());
+        let clauses = rty::relate_sub_param_types(&entry_ty.params, &expected.params);
         self.ctx.extend_clauses(clauses);
     }
 }
@@ -1019,7 +1020,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         self.unelaborate_derefs();
         self.reassign_local_mutabilities();
         self.refine_basic_blocks();
-        self.analyze_basic_blocks();
+        self.analyze_basic_blocks(expected);
         self.assert_entry(expected);
     }
 }

--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -854,7 +854,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             let rty = self
                 .type_builder
                 .for_template(&mut self.ctx)
-                .build_basic_block(live_locals, ret_ty);
+                .build_basic_block(&self.body, live_locals, ret_ty);
             self.ctx.register_basic_block_ty(self.local_def_id, bb, rty);
         }
     }
@@ -969,7 +969,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     }
 
     fn assert_entry(&mut self, expected: &rty::RefinedType) {
-        let entry_ty = self
+        let mut entry_ty = self
             .ctx
             .basic_block_ty(self.local_def_id, mir::START_BLOCK)
             .clone();
@@ -977,6 +977,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         let mut expected = expected.ty.as_function().cloned().unwrap();
         self.elaborate_mut_params(&mut expected);
 
+        entry_ty.truncate_outer_fn_params();
         self.drop_unused_expected_params(&mut expected, &entry_ty);
         let entry_ty = self.drop_bb_zst_params(&entry_ty);
 

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -12,6 +12,33 @@ use rustc_index::{IndexSlice, IndexVec};
 
 use pretty::{termcolor, BuildDoc, DocAllocator, DocPtr, Pretty};
 
+pub struct FunctionParams<'a, FV> {
+    pub params:
+        &'a rustc_index::IndexVec<crate::rty::FunctionParamIdx, crate::rty::RefinedType<FV>>,
+}
+
+impl<'a, 'b, 'c, D, FV> Pretty<'a, D, termcolor::ColorSpec> for &'b FunctionParams<'c, FV>
+where
+    FV: crate::chc::Var,
+    D: pretty::DocAllocator<'a, termcolor::ColorSpec>,
+    D::Doc: Clone,
+{
+    fn pretty(self, allocator: &'a D) -> pretty::DocBuilder<'a, D, termcolor::ColorSpec> {
+        let separator = allocator.text(",").append(allocator.line());
+        allocator
+            .intersperse(self.params.iter().map(|ty| ty.pretty(allocator)), separator)
+            .parens()
+    }
+}
+
+impl<'a, FV> FunctionParams<'a, FV> {
+    pub fn new(
+        params: &'a IndexVec<crate::rty::FunctionParamIdx, crate::rty::RefinedType<FV>>,
+    ) -> FunctionParams<'a, FV> {
+        FunctionParams { params }
+    }
+}
+
 /// A wrapper around a [`crate::rty::FunctionType`] that provides a [`Pretty`] implementation.
 pub struct FunctionType<'a, FV> {
     pub params:
@@ -26,10 +53,9 @@ where
     D::Doc: Clone,
 {
     fn pretty(self, allocator: &'a D) -> pretty::DocBuilder<'a, D, termcolor::ColorSpec> {
-        let separator = allocator.text(",").append(allocator.line());
-        allocator
-            .intersperse(self.params.iter().map(|ty| ty.pretty(allocator)), separator)
-            .parens()
+        let params = FunctionParams::new(self.params);
+        params
+            .pretty(allocator)
             .append(allocator.space())
             .append(allocator.text("→"))
             .append(allocator.line())

--- a/src/refine.rs
+++ b/src/refine.rs
@@ -11,7 +11,7 @@ mod template;
 pub use template::{TemplateRegistry, TemplateScope, TypeBuilder};
 
 mod basic_block;
-pub use basic_block::BasicBlockType;
+pub use basic_block::{BasicBlockType, BasicBlockTypeParamKind};
 
 mod env;
 pub use env::{

--- a/src/refine/basic_block.rs
+++ b/src/refine/basic_block.rs
@@ -26,17 +26,16 @@ where
 {
     fn pretty(self, allocator: &'a D) -> pretty::DocBuilder<'a, D, termcolor::ColorSpec> {
         let separator = allocator.text(",").append(allocator.line());
-        let params = self
-            .ty
-            .params
-            .iter()
-            .zip(&self.locals)
-            .map(|(ty, (local, mutbl))| {
+        let params = self.ty.params.iter_enumerated().map(|(idx, ty)| {
+            if let Some((local, mutbl)) = self.locals.get(idx) {
                 allocator
                     .text(format!("{}{:?}:", mutbl.prefix_str(), local))
                     .append(allocator.space())
                     .append(ty.pretty(allocator))
-            });
+            } else {
+                ty.pretty(allocator)
+            }
+        });
         allocator
             .intersperse(params, separator)
             .parens()

--- a/src/refine/basic_block.rs
+++ b/src/refine/basic_block.rs
@@ -1,11 +1,36 @@
 //! The refinement type for a basic block.
 
+use std::collections::HashMap;
+
 use pretty::{termcolor, Pretty};
 use rustc_index::IndexVec;
 use rustc_middle::mir::Local;
 use rustc_middle::ty as mir_ty;
 
 use crate::rty;
+
+#[derive(Debug, Clone)]
+pub enum BasicBlockTypeParamKind {
+    Local(Local, mir_ty::Mutability),
+    OuterFnParam(rty::FunctionParamIdx),
+    Synthetic,
+}
+
+impl BasicBlockTypeParamKind {
+    pub fn local(&self) -> Option<Local> {
+        match self {
+            BasicBlockTypeParamKind::Local(local, _) => Some(*local),
+            _ => None,
+        }
+    }
+
+    pub fn outer_fn_param_idx(&self) -> Option<rty::FunctionParamIdx> {
+        match self {
+            BasicBlockTypeParamKind::OuterFnParam(idx) => Some(*idx),
+            _ => None,
+        }
+    }
+}
 
 /// A special case of [`rty::FunctionType`] whose parameters are associated with [`Local`]s.
 ///
@@ -17,6 +42,8 @@ pub struct BasicBlockType {
     // TODO: make this completely private by exposing appropriate ctor
     pub(super) ty: rty::FunctionType,
     pub(super) locals: IndexVec<rty::FunctionParamIdx, (Local, mir_ty::Mutability)>,
+    // XXX: needs this to disambiguate synthetic unit param from outer fn unit param
+    pub(super) outer_fn_param_count: usize,
 }
 
 impl<'a, D> Pretty<'a, D, termcolor::ColorSpec> for &BasicBlockType
@@ -54,12 +81,28 @@ impl AsRef<rty::FunctionType> for BasicBlockType {
 }
 
 impl BasicBlockType {
+    pub fn param_kind(&self, idx: rty::FunctionParamIdx) -> BasicBlockTypeParamKind {
+        if let Some((local, mutbl)) = self.locals.get(idx) {
+            BasicBlockTypeParamKind::Local(*local, *mutbl)
+        } else if idx.index() >= self.locals.len() && self.outer_fn_param_count > 0 {
+            BasicBlockTypeParamKind::OuterFnParam(rty::FunctionParamIdx::from(
+                idx.index() - self.locals.len(),
+            ))
+        } else {
+            BasicBlockTypeParamKind::Synthetic
+        }
+    }
+
     pub fn local_of_param(&self, idx: rty::FunctionParamIdx) -> Option<Local> {
-        self.locals.get(idx).map(|(local, _)| *local)
+        self.param_kind(idx).local()
     }
 
     pub fn mutbl_of_param(&self, idx: rty::FunctionParamIdx) -> Option<mir_ty::Mutability> {
-        self.locals.get(idx).map(|(_, mutbl)| *mutbl)
+        if let BasicBlockTypeParamKind::Local(_, mutbl) = self.param_kind(idx) {
+            Some(mutbl)
+        } else {
+            None
+        }
     }
 
     pub fn local_params(&self) -> impl DoubleEndedIterator<Item = rty::FunctionParamIdx> + '_ {
@@ -73,7 +116,68 @@ impl BasicBlockType {
             .filter_map(|(idx, _)| self.local_of_param(idx))
     }
 
+    pub fn param_of_local(&self, local: Local) -> Option<rty::FunctionParamIdx> {
+        self.locals
+            .iter_enumerated()
+            .find_map(|(idx, (l, _))| if *l == local { Some(idx) } else { None })
+    }
+
     pub fn to_function_ty(&self) -> rty::FunctionType {
         self.ty.clone()
+    }
+
+    /// Inner function type of BasicBlockType contains extra parameters that carry original
+    /// function parameter values. `truncate_outer_fn_params` removes these extra parameters
+    /// to subtype output of [`BasicBlockType::to_function_ty`] against the function type.
+    ///
+    /// before: (_1: int, _2: int, int, { int |  p4 ν $0 $1 $2 }) → { int | p5 ν $0 $1 $2 $3 }
+    /// after:  (_1: int, _2: { int | p4 v $0 $1 $0 }) → { int | p5 ν $0 $1 _1 _2 }
+    ///
+    /// FIXME: this should be (&self) -> FunctionType
+    pub fn truncate_outer_fn_params(&mut self) {
+        let last_param_idx = self.ty.params.last_index().unwrap();
+        let last_param_ty = self.ty.params.raw.last().unwrap();
+
+        let mut mapping = HashMap::new();
+        for (idx, param_ty) in self.ty.params.iter_enumerated() {
+            let mapped_idx = if let Some(outer_idx) = self.param_kind(idx).outer_fn_param_idx() {
+                let corresponding_local = crate::analyze::local_of_function_param(outer_idx);
+                self.param_of_local(corresponding_local).unwrap()
+            } else {
+                idx
+            };
+            mapping.insert(idx, mapped_idx);
+
+            // to be sure
+            if idx != last_param_idx {
+                assert!(param_ty.refinement.is_top());
+            }
+        }
+
+        let last_param_refinement = last_param_ty.refinement.clone().map_var(|v| {
+            let idx = match v {
+                rty::RefinedTypeVar::Free(idx) => idx,
+                rty::RefinedTypeVar::Value => last_param_idx,
+                v => return v,
+            };
+            let mapped_idx = mapping[&idx];
+            if Some(mapped_idx) == self.locals.last_index() {
+                rty::RefinedTypeVar::Value
+            } else {
+                rty::RefinedTypeVar::Free(mapped_idx)
+            }
+        });
+
+        if !self.locals.is_empty() {
+            self.ty.params.truncate(self.locals.len());
+        }
+
+        self.ty.params.raw.last_mut().unwrap().refinement = last_param_refinement;
+        self.ty.ret.refinement = self
+            .ty
+            .ret
+            .refinement
+            .clone()
+            .map_free_var(|idx| mapping[&idx]);
     }
 }

--- a/src/refine/env.rs
+++ b/src/refine/env.rs
@@ -872,6 +872,12 @@ where
         tracing::debug!(local = ?local, rty = %rty_disp.display(), place_type = %self.local_type(local).display(), "immut_bind");
     }
 
+    pub fn immut_bind_tmp(&mut self, rty: rty::RefinedType<Var>) -> Var {
+        let idx = self.temp_vars.push(TempVarBinding::Type(rty.clone()));
+        tracing::debug!(temp = ?idx, rty = %rty.display(), "immut_bind_tmp");
+        Var::Temp(idx)
+    }
+
     pub fn assume(&mut self, assumption: impl Into<Assumption>) {
         let assumption = assumption.into();
         tracing::debug!(assumption = %assumption.display(), "assume");

--- a/src/refine/template.rs
+++ b/src/refine/template.rs
@@ -426,6 +426,7 @@ where
 
     pub fn build_basic_block<I>(
         &mut self,
+        body: &rustc_middle::mir::Body<'tcx>,
         live_locals: I,
         ret_ty: mir_ty::Ty<'tcx>,
     ) -> BasicBlockType
@@ -442,6 +443,15 @@ where
             locals.push((local, ty.mutbl));
             tys.push(ty);
         }
+
+        for arg in body.args_iter() {
+            let decl = &body.local_decls[arg];
+            tys.push(mir_ty::TypeAndMut {
+                ty: decl.ty,
+                mutbl: decl.mutability,
+            });
+        }
+
         let ty = FunctionTemplateTypeBuilder {
             inner: self.inner.clone(),
             registry: self.registry,
@@ -453,7 +463,11 @@ where
             abi: Default::default(),
         }
         .build();
-        BasicBlockType { ty, locals }
+        BasicBlockType {
+            ty,
+            locals,
+            outer_fn_param_count: body.arg_count,
+        }
     }
 }
 

--- a/src/refine/template.rs
+++ b/src/refine/template.rs
@@ -459,7 +459,10 @@ where
             ret_ty,
             param_rtys: Default::default(),
             param_refinement: None,
-            ret_rty: None,
+            // not generating pvar of BB post
+            ret_rty: Some(rty::RefinedType::unrefined(
+                self.inner.build(ret_ty).vacuous(),
+            )),
             abi: Default::default(),
         }
         .build();

--- a/src/rty.rs
+++ b/src/rty.rs
@@ -52,7 +52,7 @@ mod clause_builder;
 pub use clause_builder::ClauseBuilderExt;
 
 mod subtyping;
-pub use subtyping::{relate_sub_closed_type, ClauseScope, Subtyping};
+pub use subtyping::{relate_sub_param_types, ClauseScope, Subtyping};
 
 mod params;
 pub use params::{RefinedTypeArgs, TypeParamIdx, TypeParamSubst};

--- a/src/rty/subtyping.rs
+++ b/src/rty/subtyping.rs
@@ -1,9 +1,11 @@
 //! Translation of subtyping relations into CHC constraints.
 
+use rustc_index::IndexVec;
+
 use crate::chc;
 use crate::pretty::PrettyDisplayExt;
 
-use super::{ClauseBuilderExt as _, Closed, PointerKind, RefKind, RefinedType, Type};
+use super::{ClauseBuilderExt as _, FunctionParamIdx, PointerKind, RefKind, RefinedType, Type};
 
 /// A scope for building clauses.
 ///
@@ -170,7 +172,26 @@ where
 }
 
 #[must_use]
-pub fn relate_sub_closed_type(got: &Type<Closed>, expected: &Type<Closed>) -> Vec<chc::Clause> {
-    tracing::debug!(got = %got.display(), expected = %expected.display(), "relate_sub_closed_type");
-    chc::ClauseBuilder::default().relate_sub_type(got, expected)
+pub fn relate_sub_param_types(
+    got: &IndexVec<FunctionParamIdx, RefinedType<FunctionParamIdx>>,
+    expected: &IndexVec<FunctionParamIdx, RefinedType<FunctionParamIdx>>,
+) -> Vec<chc::Clause> {
+    assert_eq!(got.len(), expected.len());
+
+    let mut clauses = Vec::new();
+    let mut builder = chc::ClauseBuilder::default();
+
+    for (param_idx, param_rty) in got.iter_enumerated() {
+        let param_sort = param_rty.ty.to_sort();
+        if !param_sort.is_singleton() {
+            builder.add_mapped_var(param_idx, param_sort);
+        }
+    }
+
+    for (got_ty, expected_ty) in got.iter().zip(expected.iter()) {
+        let cs = builder.relate_sub_refined_type(expected_ty, got_ty);
+        clauses.extend(cs);
+    }
+
+    clauses
 }

--- a/src/rty/subtyping.rs
+++ b/src/rty/subtyping.rs
@@ -98,8 +98,9 @@ where
                     }
                 }
             }
-            (Type::Function(got), Type::Function(expected)) => {
-                // TODO: check length is equal
+            (Type::Function(got), Type::Function(expected))
+                if got.params.len() == expected.params.len() =>
+            {
                 let mut builder = chc::ClauseBuilder::default();
                 for (param_idx, param_rty) in got.params.iter_enumerated() {
                     let param_sort = param_rty.ty.to_sort();


### PR DESCRIPTION
## Summary

Each basic block in Thrust is type-checked as if it were a function with its own parameter list and return type. Previously, every basic block was given a freshly generated predicate variable for its return refinement — the basic block "post" — and a substantial amount of machinery (most visibly `UnbindAtoms`) existed to relate this post back to the enclosing function's actual return type. This PR removes the post predicate variable and the machinery that depended on it.

## Why the post existed

The enclosing function's return refinement `Q_f` is expressed in terms of the function's parameters (e.g. `*x` or `^x` for a `&mut` parameter `x`). To discharge `Q_f` at a `Return` terminator, we need the parameters' representation *at function entry* — not their representation at the basic block we happen to be returning from. Inside the function body these are different things: place contexts are flow-sensitive and reborrow/borrow elaboration can rewrite a parameter's representation along the way, so the value `env.local_type(fn_arg)` gives you in a non-entry block is not the value `Q_f` is talking about.

Each basic block is also analyzed in its own fresh scope, so the logical variables introduced for parameters at the entry block aren't directly visible in other blocks either. Something had to bridge the two.

The previous design bridged it indirectly. Every basic block was given a generated post predicate variable, and every terminator emitted a return-side subtyping clause `got.ret ⟹ expected_ret` in addition to the parameter-side clauses for the goto. Chained together across the control-flow graph, these clauses transported the function's return refinement from the entry block down to wherever `Return` actually happened. `UnbindAtoms` then existed to perform the translation between the environment-bound result type and the function-parameter-relative form expected by the post.

It worked, but the post was almost always a tautological link in this chain rather than a useful abstraction. The indirection cost real complexity in the analyzer, and it also inflated the CHC system handed to the backend solver: every basic block contributed an extra predicate variable, and every terminator contributed an extra clause, almost all of them carrying no real verification content.

## The approach

The post is only needed to carry the function-entry view of parameters down to the `Return`. So carry it explicitly: each basic block's parameter list now includes the original outer function arguments as additional parameters. These slots are passed through unchanged across every goto — they are identity-transferred from predecessor to successor — and they are available, as variables in scope, wherever the block ends up emitting its `Return` clause.

With those slots in scope at the `Return`, the block's result can be related directly against the actual `Q_f`. No generated post predicate, no chain of `got.ret ⟹ expected_ret` clauses across terminators, no translation step back from the environment scope to the parameter scope.

## Consequences

- The post predicate variable per basic block disappears. Each block now has just a pre.
- The return-side of every terminator's subtyping is gone; only the `Return` terminator emits a clause involving `Q_f`.
- `ret_template` is no longer needed.
- `UnbindAtoms` and the infrastructure built around it become dead code and are removed.

The cost is a slightly higher arity on the pre predicate (extra slots for the outer function arguments), which should be uniformly cheaper than the eliminated predicated variables in practice.