### PR TITLE
Fix unsoundness from closure capturing &mut in a struct/tuple field (#41)

### DIFF
--- a/src/analyze/basic_block/drop_point.rs
+++ b/src/analyze/basic_block/drop_point.rs
@@ -57,6 +57,50 @@ pub struct DropPointsBuilder<'mir, 'tcx> {
     bb_ins_cache: HashMap<BasicBlock, DenseBitSet<Local>>,
 }
 
+/// Locals whose ownership is fully transferred away by the statement (or
+/// terminator) at `statement_index`. Such a local is left uninitialized, so its
+/// drop obligation (including resolving any mutable-borrow prophecies it owns)
+/// moves to the destination and it must not be dropped at the move site.
+///
+/// Only owned (non-reference) operands are reported: `move`d references are
+/// turned into reborrows by `ReborrowVisitor`/`RustCallVisitor`, so the source
+/// local remains live and must still be dropped.
+fn moved_locals<'tcx>(
+    body: &Body<'tcx>,
+    bb: BasicBlock,
+    statement_index: usize,
+) -> DenseBitSet<Local> {
+    struct Visitor<'a, 'tcx> {
+        body: &'a Body<'tcx>,
+        locals: DenseBitSet<Local>,
+    }
+    impl<'tcx> mir::visit::Visitor<'tcx> for Visitor<'_, 'tcx> {
+        fn visit_operand(&mut self, operand: &mir::Operand<'tcx>, _location: mir::Location) {
+            if let mir::Operand::Move(place) = operand {
+                if place.projection.is_empty() && !self.body.local_decls[place.local].ty.is_ref() {
+                    self.locals.insert(place.local);
+                }
+            }
+        }
+    }
+    let mut visitor = Visitor {
+        body,
+        locals: DenseBitSet::new_empty(body.local_decls.len()),
+    };
+    let loc = mir::Location {
+        statement_index,
+        block: bb,
+    };
+    let data = &body.basic_blocks[bb];
+    use mir::visit::Visitor as _;
+    if statement_index < data.statements.len() {
+        visitor.visit_statement(&data.statements[statement_index], loc);
+    } else if let Some(tmnt) = &data.terminator {
+        visitor.visit_terminator(tmnt, loc);
+    }
+    visitor.locals
+}
+
 fn def_local<'tcx>(data: &mir::BasicBlockData<'tcx>, statement_index: usize) -> Option<Local> {
     struct Visitor {
         local: Option<Local>,
@@ -135,6 +179,7 @@ impl<'mir, 'tcx> DropPointsBuilder<'mir, 'tcx> {
                     t.insert(def);
                 }
                 t.subtract(&last_live_locals);
+                t.subtract(&moved_locals(self.body, bb, statement_index));
                 t
             };
             last_live_locals = live_locals;

--- a/tests/ui/fail/closure_field_mut.rs
+++ b/tests/ui/fail/closure_field_mut.rs
@@ -1,0 +1,13 @@
+//@error-in-other-file: Unsat
+
+fn main() {
+    let mut call_count = 0;
+    let mut s = (
+        || {
+            call_count = 1;
+        },
+        0,
+    );
+    (s.0)();
+    assert!(call_count == 0);
+}

--- a/tests/ui/pass/closure_field_mut.rs
+++ b/tests/ui/pass/closure_field_mut.rs
@@ -1,0 +1,13 @@
+//@check-pass
+
+fn main() {
+    let mut call_count = 0;
+    let mut s = (
+        || {
+            call_count = 1;
+        },
+        0,
+    );
+    (s.0)();
+    assert!(call_count == 1);
+}


### PR DESCRIPTION
## Summary

Fixes #41. A closure capturing `&mut` stored in a tuple/struct field made thrust derive a contradictory environment and unsoundly accept programs that can panic (the issue's `assert!(false)` was proven unreachable).

## Root cause

The drop-point analysis (`src/analyze/basic_block/drop_point.rs`) treats a local's last use as its drop site, based purely on liveness. When a value is moved into an aggregate (e.g. a closure moved into a tuple via `_2 = (move _3, 0)`), the moved-out temporary `_3` was still dropped at the move site. Dropping a value containing a `&mut` asserts `final == current` on the captured reference, which prematurely resolves its prophecy to the construction-time value (`0`). The subsequent `(s.0)()` call mutates through the closure (`final = 1`), contradicting the pinned `0`. An inconsistent environment makes any following assertion vacuously "safe" — the unsoundness.

## Fix

Exclude owned (non-reference) locals whose ownership is transferred away by a `move` from the drop set — their drop obligation belongs to the destination. Moved *references* are deliberately left untouched, because `ReborrowVisitor`/`RustCallVisitor` rewrite them into reborrows, so the source local stays live and must still be dropped. (Restricting to non-reference types is essential: suppressing all moved-local drops regresses cases like `closure_mut_0`, where the original MIR `move`s a `&mut` that thrust reborrows.)

https://claude.ai/code/session_01HHar2z2xTNwffns5SF7wRe

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHar2z2xTNwffns5SF7wRe)_