### PR TITLE
Handle ZeroSized constants in const_value_ty

### DIFF
--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -402,6 +402,9 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             (mir_ty::TyKind::Closure(_, args), _) if args.as_closure().upvar_tys().is_empty() => {
                 PlaceType::with_ty_and_term(rty::Type::unit(), chc::Term::tuple(vec![]))
             }
+            (_, ConstValue::ZeroSized) => {
+                PlaceType::with_ty_and_term(rty::Type::unit(), chc::Term::tuple(vec![]))
+            }
             (
                 mir_ty::TyKind::Ref(_, elem, Mutability::Not),
                 ConstValue::Scalar(Scalar::Ptr(ptr, _)),

--- a/tests/ui/fail/adt_unit_struct.rs
+++ b/tests/ui/fail/adt_unit_struct.rs
@@ -1,21 +1,15 @@
-//@check-pass
+//@error-in-other-file: Unsat
 //@compile-flags: -C debug-assertions=off
 
 struct Counter;
-struct Token;
 
 fn use_counter(c: Counter) -> Counter {
     let _x: Counter = c;
     _x
 }
 
-fn take_token(mut t: Token) -> Token {
-    t = Token;
-    t
-}
-
 fn main() {
     let c = Counter;
     let _ = use_counter(c);
-    let _ = take_token(Token);
+    assert!(false);
 }

--- a/tests/ui/pass/adt_unit_struct.rs
+++ b/tests/ui/pass/adt_unit_struct.rs
@@ -1,0 +1,20 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+struct Counter;
+
+fn use_counter(c: Counter) -> Counter {
+    let _x: Counter = c;
+    _x
+}
+
+fn take_token(mut t: Counter) -> Counter {
+    t = Counter;
+    t
+}
+
+fn main() {
+    let c = Counter;
+    let _ = use_counter(c);
+    let _ = take_token(Counter);
+}

--- a/tests/ui/pass/zst.rs
+++ b/tests/ui/pass/zst.rs
@@ -1,0 +1,21 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+struct Counter;
+struct Token;
+
+fn use_counter(c: Counter) -> Counter {
+    let _x: Counter = c;
+    _x
+}
+
+fn take_token(mut t: Token) -> Token {
+    t = Token;
+    t
+}
+
+fn main() {
+    let c = Counter;
+    let _ = use_counter(c);
+    let _ = take_token(Token);
+}


### PR DESCRIPTION
apparently, #72 is fixed by https://github.com/coord-e/thrust/pull/90