### PR TITLE
Refer to closure pre-/post-conditions in specifications

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -233,6 +233,10 @@ impl<'tcx> crate::refine::TemplateRegistry for Analyzer<'tcx> {
 }
 
 impl<'tcx> Analyzer<'tcx> {
+    pub fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     pub fn generate_pred_var(&mut self, sig: chc::PredSig) -> chc::PredVarId {
         self.system
             .borrow_mut()
@@ -400,6 +404,29 @@ impl<'tcx> Analyzer<'tcx> {
         })
     }
 
+    // TODO: Remove this cache-only accessor together with
+    // `local_def::Analyzer::precompute_callable_param_contracts` once `def_ty_with_args` can be
+    // used from formula translation without requiring `&mut Analyzer`.
+    pub fn known_function_ty_with_args(
+        &self,
+        def_id: DefId,
+        generic_args: mir_ty::GenericArgsRef<'tcx>,
+    ) -> Option<rty::FunctionType> {
+        let type_builder = TypeBuilder::new(self.tcx, self.def_ids(), def_id);
+        let mut def_ty = match self.defs.get(&def_id)? {
+            DefTy::Concrete(rty) => rty.clone(),
+            DefTy::Deferred(deferred) => deferred.cache.borrow().get(&generic_args)?.clone(),
+        };
+        def_ty.instantiate_ty_params(
+            generic_args
+                .types()
+                .map(|ty| type_builder.build(ty))
+                .map(rty::RefinedType::unrefined)
+                .collect(),
+        );
+        def_ty.ty.as_function().cloned()
+    }
+
     pub fn formula_fn_with_args(
         &self,
         local_def_id: LocalDefId,
@@ -412,7 +439,7 @@ impl<'tcx> Analyzer<'tcx> {
             return Some(formula_fn.clone());
         }
 
-        let translator = annot_fn::AnnotFnTranslator::new(self.tcx, local_def_id)
+        let translator = annot_fn::AnnotFnTranslator::new(self, local_def_id)
             .with_generic_args(generic_args)
             .with_def_id_cache(self.def_ids());
         let formula_fn = translator.to_formula_fn();

--- a/src/analyze/annot.rs
+++ b/src/analyze/annot.rs
@@ -149,6 +149,22 @@ pub fn invariant_marker_path() -> [Symbol; 3] {
     ]
 }
 
+pub fn closure_precondition_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("closure_precondition"),
+    ]
+}
+
+pub fn closure_postcondition_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("closure_postcondition"),
+    ]
+}
+
 /// A [`annot::Resolver`] implementation for resolving function parameters.
 ///
 /// The parameter names and their sorts needs to be configured via

--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -130,9 +130,10 @@ impl<T> FormulaOrTerm<T> {
 }
 
 #[derive(Clone)]
-pub struct AnnotFnTranslator<'tcx> {
+pub struct AnnotFnTranslator<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     local_def_id: LocalDefId,
+    analyzer: &'a analyze::Analyzer<'tcx>,
 
     typeck: &'tcx mir_ty::TypeckResults<'tcx>,
     body: &'tcx rustc_hir::Body<'tcx>,
@@ -143,16 +144,18 @@ pub struct AnnotFnTranslator<'tcx> {
     env: HashMap<HirId, chc::Term<rty::FunctionParamIdx>>,
 }
 
-impl<'tcx> AnnotFnTranslator<'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>, local_def_id: LocalDefId) -> Self {
+impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
+    pub fn new(analyzer: &'a analyze::Analyzer<'tcx>, local_def_id: LocalDefId) -> Self {
+        let tcx = analyzer.tcx();
         let body = tcx.hir_body_owned_by(local_def_id);
         let generic_args = tcx.mk_args(&[]);
         let typeck = tcx.typeck(local_def_id);
-        let def_ids = DefIdCache::new(tcx);
+        let def_ids = analyzer.def_ids();
         let type_builder = TypeBuilder::new(tcx, def_ids.clone(), local_def_id.to_def_id());
         let mut translator = Self {
             tcx,
             local_def_id,
+            analyzer,
             typeck,
             body,
             generic_args,
@@ -247,6 +250,110 @@ impl<'tcx> AnnotFnTranslator<'tcx> {
         self.to_formula_or_term(hir)
             .into_term()
             .expect("expected a term")
+    }
+
+    /// Resolves the [`rty::FunctionType`] of the closure parameter referred to by `receiver` (the
+    /// closure argument of a `closure_precondition(..)` / `closure_postcondition(..)` call).
+    ///
+    /// The receiver is instantiated to the actual closure type in the formula function; its `DefId`
+    /// is used to look up the contract collected by the analyzer.
+    fn receiver_closure_fn_type(
+        &self,
+        receiver: &'tcx rustc_hir::Expr<'tcx>,
+    ) -> Option<rty::FunctionType> {
+        let mut recv_ty = self.expr_ty(receiver);
+        if let mir_ty::TyKind::Ref(_, inner, _) = recv_ty.kind() {
+            recv_ty = *inner;
+        }
+        let mir_ty::TyKind::Closure(def_id, args) = recv_ty.kind() else {
+            return None;
+        };
+        self.analyzer
+            .known_function_ty_with_args(*def_id, self.tcx.mk_args(args.as_closure().parent_args()))
+    }
+
+    /// Extracts the logical argument terms passed to `closure_precondition`/
+    /// `closure_postcondition`. The arguments are supplied as a single tuple (e.g. `(x,)` or
+    /// `()`), whose elements are the logical arguments of the closure.
+    fn closure_spec_args(
+        &self,
+        arg: &'tcx rustc_hir::Expr<'tcx>,
+    ) -> Vec<chc::Term<rty::FunctionParamIdx>> {
+        match arg.kind {
+            rustc_hir::ExprKind::Tup(elems) => elems.iter().map(|e| self.to_term(e)).collect(),
+            _ => vec![self.to_term(arg)],
+        }
+    }
+
+    /// The term of the closure value referred to by `receiver` (the `&f` argument of a marker call).
+    fn closure_value_term(
+        &self,
+        receiver: &'tcx rustc_hir::Expr<'tcx>,
+    ) -> chc::Term<rty::FunctionParamIdx> {
+        match receiver.kind {
+            rustc_hir::ExprKind::AddrOf(
+                rustc_hir::BorrowKind::Ref,
+                rustc_hir::Mutability::Not,
+                operand,
+            ) => self.to_term(operand),
+            _ => self.to_term(receiver),
+        }
+    }
+
+    /// The values of a closure's parameters: the closure's first (RustCall) parameter is its
+    /// environment, which is the closure value itself, followed by the logical arguments.
+    fn translate_closure_precondition(
+        &self,
+        receiver: &'tcx rustc_hir::Expr<'tcx>,
+        args: &'tcx rustc_hir::Expr<'tcx>,
+    ) -> FormulaOrTerm<rty::FunctionParamIdx> {
+        let fn_ty = self.receiver_closure_fn_type(receiver).unwrap_or_else(|| {
+            panic!(
+                "precondition used on a non-closure parameter: {:?}",
+                receiver
+            )
+        });
+        let logical_args = self.closure_spec_args(args);
+        // `fn_ty` is a closure (RustCall ABI), so its parameters are `[env, args..]`, where the
+        // environment is the closure value itself.
+        assert_eq!(
+            logical_args.len(),
+            fn_ty.params.len() - 1,
+            "closure precondition arity mismatch: closure takes {} argument(s)",
+            fn_ty.params.len() - 1
+        );
+        let param_args: Vec<_> = std::iter::once(self.closure_value_term(receiver))
+            .chain(logical_args)
+            .collect();
+        FormulaOrTerm::Formula(fn_ty.precondition_formula(&param_args))
+    }
+
+    fn translate_closure_postcondition(
+        &self,
+        receiver: &'tcx rustc_hir::Expr<'tcx>,
+        args: &'tcx rustc_hir::Expr<'tcx>,
+        result: &'tcx rustc_hir::Expr<'tcx>,
+    ) -> FormulaOrTerm<rty::FunctionParamIdx> {
+        let fn_ty = self.receiver_closure_fn_type(receiver).unwrap_or_else(|| {
+            panic!(
+                "postcondition used on a non-closure parameter: {:?}",
+                receiver
+            )
+        });
+        let logical_args = self.closure_spec_args(args);
+        // `fn_ty` is a closure (RustCall ABI), so its parameters are `[env, args..]`, where the
+        // environment is the closure value itself.
+        assert_eq!(
+            logical_args.len(),
+            fn_ty.params.len() - 1,
+            "closure postcondition arity mismatch: closure takes {} argument(s)",
+            fn_ty.params.len() - 1
+        );
+        let param_args: Vec<_> = std::iter::once(self.closure_value_term(receiver))
+            .chain(logical_args)
+            .collect();
+        let result = self.to_term(result);
+        FormulaOrTerm::Formula(fn_ty.postcondition_formula(&param_args, result))
     }
 
     fn variant_ctor_term(
@@ -425,6 +532,22 @@ impl<'tcx> AnnotFnTranslator<'tcx> {
                 if let ExprKind::Path(qpath) = &func_expr.kind {
                     let res = self.typeck.qpath_res(qpath, func_expr.hir_id);
                     if let rustc_hir::def::Res::Def(def_kind, def_id) = res {
+                        if Some(def_id) == self.def_ids.closure_precondition() {
+                            let [receiver, args] = args else {
+                                panic!(
+                                    "closure_precondition takes a closure and a tuple of arguments"
+                                );
+                            };
+                            return self.translate_closure_precondition(receiver, args);
+                        }
+                        if Some(def_id) == self.def_ids.closure_postcondition() {
+                            let [receiver, args, result] = args else {
+                                panic!(
+                                    "closure_postcondition takes a closure, a tuple of arguments, and a result"
+                                );
+                            };
+                            return self.translate_closure_postcondition(receiver, args, result);
+                        }
                         if Some(def_id) == self.def_ids.exists() {
                             assert_eq!(args.len(), 1, "exists takes exactly 1 argument");
                             let ExprKind::Closure(closure) = args[0].kind else {

--- a/src/analyze/did_cache.rs
+++ b/src/analyze/did_cache.rs
@@ -26,6 +26,9 @@ struct DefIds {
 
     exists: OnceCell<Option<DefId>>,
     invariant_marker: OnceCell<Option<DefId>>,
+
+    closure_precondition: OnceCell<Option<DefId>>,
+    closure_postcondition: OnceCell<Option<DefId>>,
 }
 
 /// Retrieves and caches well-known [`DefId`]s.
@@ -183,5 +186,18 @@ impl<'tcx> DefIdCache<'tcx> {
             .def_ids
             .invariant_marker
             .get_or_init(|| self.annotated_def(&crate::analyze::annot::invariant_marker_path()))
+    }
+
+    pub fn closure_precondition(&self) -> Option<DefId> {
+        *self
+            .def_ids
+            .closure_precondition
+            .get_or_init(|| self.annotated_def(&crate::analyze::annot::closure_precondition_path()))
+    }
+
+    pub fn closure_postcondition(&self) -> Option<DefId> {
+        *self.def_ids.closure_postcondition.get_or_init(|| {
+            self.annotated_def(&crate::analyze::annot::closure_postcondition_path())
+        })
     }
 }

--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -320,6 +320,30 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         self.ctx.def_ty_with_args(trait_item_did, trait_ref.args)
     }
 
+    // TODO: Remove this eager precompute together with
+    // `Analyzer::known_function_ty_with_args` once formula translation can call a read-only
+    // `def_ty_with_args` directly.
+    fn precompute_callable_param_contracts(&mut self, sig: &mir_ty::FnSig<'tcx>) {
+        for input_ty in sig.inputs() {
+            let inst =
+                mir_ty::EarlyBinder::bind(*input_ty).instantiate(self.tcx, self.generic_args);
+            let inst = self
+                .tcx
+                .normalize_erasing_regions(mir_ty::TypingEnv::fully_monomorphized(), inst);
+            let (fn_def_id, fn_args) = match inst.kind() {
+                mir_ty::TyKind::Closure(def_id, args) => {
+                    (*def_id, self.tcx.mk_args(args.as_closure().parent_args()))
+                }
+                mir_ty::TyKind::FnDef(def_id, args) => (*def_id, *args),
+                _ => continue,
+            };
+            if fn_def_id == self.local_def_id.to_def_id() {
+                continue;
+            }
+            let _ = self.ctx.def_ty_with_args(fn_def_id, fn_args);
+        }
+    }
+
     // Note that we do not expect predicate variables to be generated here
     // when type params are still present in the type. Callers should ensure either
     // - type params are fully instantiated, or
@@ -351,6 +375,11 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             .resolver((&param_resolver).map(rty::RefinedTypeVar::Free));
 
         let self_type_name = self.impl_type().map(|ty| ty.to_string());
+
+        // Formula translation for `pre!(f(..))`/`post!(f(..), result)` is read-only. If a callable
+        // parameter resolves to a deferred closure/function def, force its analysis here so the
+        // translator can later find the cached contract.
+        self.precompute_callable_param_contracts(&sig);
 
         let mut require_annot = self.ctx.extract_require_annot(
             self.local_def_id,

--- a/src/rty.rs
+++ b/src/rty.rs
@@ -231,6 +231,95 @@ impl FunctionType {
         self.ret = Box::new(old_ret.map_var(shift));
         removed
     }
+
+    /// Maps each parameter of this function type to the logical term that represents its value,
+    /// given the parameter values `args` supplied at a (spec-level) application site.
+    ///
+    /// The i-th argument is the value of the i-th parameter; there must be exactly one argument per
+    /// parameter. For closures ([`FunctionAbi::RustCall`]), the caller supplies the closure
+    /// environment as the first argument.
+    fn param_terms<W>(&self, args: &[chc::Term<W>]) -> IndexVec<FunctionParamIdx, chc::Term<W>>
+    where
+        W: chc::Var,
+    {
+        assert_eq!(
+            args.len(),
+            self.params.len(),
+            "expected exactly one argument per parameter"
+        );
+        self.params
+            .indices()
+            .map(|idx| args[idx.index()].clone())
+            .collect()
+    }
+
+    /// The precondition of this function instantiated with the parameter values `args`, expressed as
+    /// a [`chc::Formula`] in the caller's variable space `W`.
+    ///
+    /// The precondition is the conjunction of the refinements of all parameters, with each
+    /// parameter's value variable replaced by the corresponding argument term.
+    pub fn precondition_formula<W>(&self, args: &[chc::Term<W>]) -> chc::Formula<W>
+    where
+        W: chc::Var,
+    {
+        let param_terms = self.param_terms(args);
+        let mut acc = chc::Formula::top();
+        for (idx, param) in self.params.iter_enumerated() {
+            let f = refinement_to_chc_formula(
+                &param.refinement,
+                param_terms[idx].clone(),
+                &param_terms,
+            );
+            acc = acc.and(f);
+        }
+        acc
+    }
+
+    /// The postcondition of this function instantiated with the parameter values `args` and return
+    /// value `result`, expressed as a [`chc::Formula`] in the caller's variable space `W`.
+    pub fn postcondition_formula<W>(
+        &self,
+        args: &[chc::Term<W>],
+        result: chc::Term<W>,
+    ) -> chc::Formula<W>
+    where
+        W: chc::Var,
+    {
+        let param_terms = self.param_terms(args);
+        refinement_to_chc_formula(&self.ret.refinement, result, &param_terms)
+    }
+}
+
+/// Lowers a [`Refinement`] (over [`FunctionParamIdx`]) into a [`chc::Formula`] in the caller's
+/// variable space `W`, substituting [`RefinedTypeVar::Value`] with `value` and
+/// [`RefinedTypeVar::Free`] with the corresponding entry of `param_terms`.
+///
+/// Closure parameter/return refinements are predicate-variable templates without existentials, so
+/// [`RefinedTypeVar::Existential`] is not expected here.
+fn refinement_to_chc_formula<W>(
+    refinement: &Refinement<FunctionParamIdx>,
+    value: chc::Term<W>,
+    param_terms: &IndexVec<FunctionParamIdx, chc::Term<W>>,
+) -> chc::Formula<W>
+where
+    W: chc::Var,
+{
+    assert!(
+        refinement.existentials.is_empty(),
+        "closure refinements with existentials are not supported"
+    );
+
+    let body = refinement.body.clone().subst_var(|v| match v {
+        RefinedTypeVar::Value => value.clone(),
+        RefinedTypeVar::Free(j) => param_terms[j].clone(),
+        RefinedTypeVar::Existential(_) => unreachable!("closure refinement has no existentials"),
+    });
+
+    let mut formula = body.formula;
+    for atom in body.atoms {
+        formula = formula.and(chc::Formula::Atom(atom));
+    }
+    formula
 }
 
 /// The kind of a reference, which is either mutable or immutable.

--- a/std.rs
+++ b/std.rs
@@ -158,6 +158,25 @@ mod thrust_models {
         #[thrust::def::closure_model]
         pub struct Closure<T: ?Sized>(PhantomData<T>);
 
+        /// Refers to the precondition of a closure in a specification.
+        ///
+        /// `args` is the tuple of logical arguments (`(x,)` for one argument, `()` for none).
+        #[allow(dead_code)]
+        #[thrust::def::closure_precondition]
+        #[thrust::ignored]
+        pub fn closure_precondition<F: ?Sized, Args>(_f: &F, _args: Args) -> bool {
+            unimplemented!()
+        }
+
+        /// Refers to the postcondition of a closure in a specification, relating the
+        /// logical arguments `args` to the closure's `result`.
+        #[allow(dead_code)]
+        #[thrust::def::closure_postcondition]
+        #[thrust::ignored]
+        pub fn closure_postcondition<F: ?Sized, Args, R>(_f: &F, _args: Args, _result: R) -> bool {
+            unimplemented!()
+        }
+
         pub struct Vec<T: ?Sized>(pub Array<Int, T>, pub Int);
 
         impl<T, U> PartialEq<U> for Vec<T> where U: super::Model<Ty = Self> {
@@ -385,6 +404,42 @@ fn _extern_spec_option_is_some<T>(opt: &Option<T>) -> bool where T: thrust_model
 )]
 fn _extern_spec_option_unwrap_or<T>(opt: Option<T>, default: T) -> T where T: thrust_models::Model, T::Ty: PartialEq {
     Option::unwrap_or(opt, default)
+}
+
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(
+    opt == None
+        || thrust_models::exists(|i| opt == Some(i)
+            && thrust_models::model::closure_precondition(&(f), (i,)))
+)]
+#[thrust_macros::ensures(
+    (opt == None && result == None)
+    || thrust_models::exists(|i| thrust_models::exists(|j|
+        opt == Some(i)
+            && thrust_models::model::closure_postcondition(&(f), (i,), j)
+            && result == Some(j)))
+)]
+fn _extern_spec_option_map<T, U, F>(opt: Option<T>, f: F) -> Option<U>
+where
+    T: thrust_models::Model, T::Ty: PartialEq,
+    U: thrust_models::Model, U::Ty: PartialEq,
+    F: FnOnce(T) -> U,
+{
+    Option::map(opt, f)
+}
+
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(opt != None || thrust_models::model::closure_precondition(&(f), ()))]
+#[thrust_macros::ensures(
+    (opt != None && Some(result) == opt)
+    || (opt == None && thrust_models::model::closure_postcondition(&(f), (), result))
+)]
+fn _extern_spec_option_unwrap_or_else<T, F>(opt: Option<T>, f: F) -> T
+where
+    T: thrust_models::Model, T::Ty: PartialEq,
+    F: FnOnce() -> T,
+{
+    Option::unwrap_or_else(opt, f)
 }
 
 #[thrust::extern_spec_fn]

--- a/std.rs
+++ b/std.rs
@@ -160,7 +160,8 @@ mod thrust_models {
 
         /// Refers to the precondition of a closure in a specification.
         ///
-        /// `args` is the tuple of logical arguments (`(x,)` for one argument, `()` for none).
+        /// Prefer the `thrust_macros::pre!(f(x))` surface syntax, which desugars to this; the
+        /// `args` here is the tuple of logical arguments (`(x,)` for one argument, `()` for none).
         #[allow(dead_code)]
         #[thrust::def::closure_precondition]
         #[thrust::ignored]
@@ -170,6 +171,8 @@ mod thrust_models {
 
         /// Refers to the postcondition of a closure in a specification, relating the
         /// logical arguments `args` to the closure's `result`.
+        ///
+        /// Prefer the `thrust_macros::post!(f(x), r)` surface syntax, which desugars to this.
         #[allow(dead_code)]
         #[thrust::def::closure_postcondition]
         #[thrust::ignored]
@@ -408,16 +411,12 @@ fn _extern_spec_option_unwrap_or<T>(opt: Option<T>, default: T) -> T where T: th
 
 #[thrust::extern_spec_fn]
 #[thrust_macros::requires(
-    opt == None
-        || thrust_models::exists(|i| opt == Some(i)
-            && thrust_models::model::closure_precondition(&(f), (i,)))
+    opt == None || thrust_models::exists(|i| opt == Some(i) && thrust_macros::pre!(f(i)))
 )]
 #[thrust_macros::ensures(
     (opt == None && result == None)
     || thrust_models::exists(|i| thrust_models::exists(|j|
-        opt == Some(i)
-            && thrust_models::model::closure_postcondition(&(f), (i,), j)
-            && result == Some(j)))
+        opt == Some(i) && thrust_macros::post!(f(i), j) && result == Some(j)))
 )]
 fn _extern_spec_option_map<T, U, F>(opt: Option<T>, f: F) -> Option<U>
 where
@@ -429,10 +428,10 @@ where
 }
 
 #[thrust::extern_spec_fn]
-#[thrust_macros::requires(opt != None || thrust_models::model::closure_precondition(&(f), ()))]
+#[thrust_macros::requires(opt != None || thrust_macros::pre!(f()))]
 #[thrust_macros::ensures(
     (opt != None && Some(result) == opt)
-    || (opt == None && thrust_models::model::closure_postcondition(&(f), (), result))
+    || (opt == None && thrust_macros::post!(f(), result))
 )]
 fn _extern_spec_option_unwrap_or_else<T, F>(opt: Option<T>, f: F) -> T
 where

--- a/tests/ui/fail/closure_postcondition.rs
+++ b/tests/ui/fail/closure_postcondition.rs
@@ -1,0 +1,14 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(thrust_models::model::closure_precondition(&(f), (x,)))]
+#[thrust_macros::ensures(thrust_models::model::closure_postcondition(&(f), (x,), result))]
+fn apply<F: FnOnce(i32) -> i32>(x: i32, f: F) -> i32 {
+    f(x)
+}
+
+fn main() {
+    let r = apply(3, |y| y + 1);
+    // r == 4, so this assertion does not hold
+    assert!(r == 5);
+}

--- a/tests/ui/fail/closure_postcondition.rs
+++ b/tests/ui/fail/closure_postcondition.rs
@@ -1,8 +1,8 @@
 //@error-in-other-file: Unsat
 //@compile-flags: -C debug-assertions=off
 
-#[thrust_macros::requires(thrust_models::model::closure_precondition(&(f), (x,)))]
-#[thrust_macros::ensures(thrust_models::model::closure_postcondition(&(f), (x,), result))]
+#[thrust_macros::requires(thrust_macros::pre!(f(x)))]
+#[thrust_macros::ensures(thrust_macros::post!(f(x), result))]
 fn apply<F: FnOnce(i32) -> i32>(x: i32, f: F) -> i32 {
     f(x)
 }

--- a/tests/ui/fail/option_map.rs
+++ b/tests/ui/fail/option_map.rs
@@ -1,0 +1,14 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+#[thrust::callable]
+fn check(opt: Option<i32>) {
+    let r = opt.map(|x| x + 1);
+    if let Some(i) = opt {
+        // r == Some(i + 1), so this assertion does not hold
+        assert!(r == Some(i + 2));
+    }
+}
+
+fn main() {}

--- a/tests/ui/fail/option_unwrap_or_else.rs
+++ b/tests/ui/fail/option_unwrap_or_else.rs
@@ -1,0 +1,15 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+#[thrust::callable]
+fn check(o: Option<i32>, d: i32) {
+    let none = o.is_none();
+    let r = o.unwrap_or_else(|| d);
+    if none {
+        // r == d in the None case, so this assertion does not hold
+        assert!(r == d + 1);
+    }
+}
+
+fn main() {}

--- a/tests/ui/pass/closure_postcondition.rs
+++ b/tests/ui/pass/closure_postcondition.rs
@@ -2,9 +2,9 @@
 //@compile-flags: -C debug-assertions=off
 
 // A higher-order function whose specification refers to the pre-/post-conditions
-// of its closure argument.
-#[thrust_macros::requires(thrust_models::model::closure_precondition(&(f), (x,)))]
-#[thrust_macros::ensures(thrust_models::model::closure_postcondition(&(f), (x,), result))]
+// of its closure argument via `pre!(f(..))` / `post!(f(..), result)`.
+#[thrust_macros::requires(thrust_macros::pre!(f(x)))]
+#[thrust_macros::ensures(thrust_macros::post!(f(x), result))]
 fn apply<F: FnOnce(i32) -> i32>(x: i32, f: F) -> i32 {
     f(x)
 }

--- a/tests/ui/pass/closure_postcondition.rs
+++ b/tests/ui/pass/closure_postcondition.rs
@@ -1,0 +1,15 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+// A higher-order function whose specification refers to the pre-/post-conditions
+// of its closure argument.
+#[thrust_macros::requires(thrust_models::model::closure_precondition(&(f), (x,)))]
+#[thrust_macros::ensures(thrust_models::model::closure_postcondition(&(f), (x,), result))]
+fn apply<F: FnOnce(i32) -> i32>(x: i32, f: F) -> i32 {
+    f(x)
+}
+
+fn main() {
+    let r = apply(3, |y| y + 1);
+    assert!(r == 4);
+}

--- a/tests/ui/pass/closure_postcondition_generic.rs
+++ b/tests/ui/pass/closure_postcondition_generic.rs
@@ -1,0 +1,17 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(thrust_models::model::closure_precondition(&(f), (x,)))]
+#[thrust_macros::ensures(thrust_models::model::closure_postcondition(&(f), (x,), result))]
+fn apply<T, F: FnOnce(T) -> T>(x: T, f: F) -> T {
+    f(x)
+}
+
+fn call_apply<T>(x: T) -> T {
+    apply(x, |y| y)
+}
+
+fn main() {
+    let r = call_apply(3);
+    assert!(r == 3);
+}

--- a/tests/ui/pass/closure_postcondition_generic.rs
+++ b/tests/ui/pass/closure_postcondition_generic.rs
@@ -1,8 +1,8 @@
 //@check-pass
 //@compile-flags: -C debug-assertions=off
 
-#[thrust_macros::requires(thrust_models::model::closure_precondition(&(f), (x,)))]
-#[thrust_macros::ensures(thrust_models::model::closure_postcondition(&(f), (x,), result))]
+#[thrust_macros::requires(thrust_macros::pre!(f(x)))]
+#[thrust_macros::ensures(thrust_macros::post!(f(x), result))]
 fn apply<T, F: FnOnce(T) -> T>(x: T, f: F) -> T {
     f(x)
 }

--- a/tests/ui/pass/option_map.rs
+++ b/tests/ui/pass/option_map.rs
@@ -1,0 +1,13 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+#[thrust::callable]
+fn check(opt: Option<i32>) {
+    let r = opt.map(|x| x + 1);
+    if let Some(i) = opt {
+        assert!(r == Some(i + 1));
+    }
+}
+
+fn main() {}

--- a/tests/ui/pass/option_unwrap_or_else.rs
+++ b/tests/ui/pass/option_unwrap_or_else.rs
@@ -1,0 +1,14 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+#[thrust::callable]
+fn check(o: Option<i32>, d: i32) {
+    let none = o.is_none();
+    let r = o.unwrap_or_else(|| d);
+    if none {
+        assert!(r == d);
+    }
+}
+
+fn main() {}

--- a/thrust-macros/src/lib.rs
+++ b/thrust-macros/src/lib.rs
@@ -6,10 +6,25 @@ mod fn_outer_item;
 mod formula_fn_type_lowering;
 mod invariant;
 mod invariant_context;
+mod pre_post;
 mod spec;
 
 use fn_outer_item::FnOuterItem;
 use formula_fn_type_lowering::FormulaFnTypeLowering;
+
+/// `pre!(f(a, b))` refers to the precondition of the closure `f` for arguments `a, b` in a
+/// specification.
+#[proc_macro]
+pub fn pre(input: TokenStream) -> TokenStream {
+    pre_post::expand_pre(input)
+}
+
+/// `post!(f(a, b), r)` refers to the postcondition of the closure `f` relating arguments
+/// `a, b` to the result `r` in a specification.
+#[proc_macro]
+pub fn post(input: TokenStream) -> TokenStream {
+    pre_post::expand_post(input)
+}
 
 #[proc_macro_attribute]
 pub fn context(_attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/thrust-macros/src/pre_post.rs
+++ b/thrust-macros/src/pre_post.rs
@@ -1,0 +1,47 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use syn::punctuated::Punctuated;
+
+/// Builds a tuple expression from a call's argument list, for the closure precondition/postcondition
+/// marker functions in `thrust_models::model`. An empty list becomes `()`; otherwise a trailing
+/// comma makes a single argument a one-element tuple (`(x,)`).
+fn call_args_tuple(args: &Punctuated<syn::Expr, syn::Token![,]>) -> TokenStream2 {
+    if args.is_empty() {
+        quote::quote!(())
+    } else {
+        let args = args.iter();
+        quote::quote!((#(#args),*,))
+    }
+}
+
+pub fn expand_pre(input: TokenStream) -> TokenStream {
+    let call = syn::parse_macro_input!(input as syn::ExprCall);
+    let func = &*call.func;
+    let args = call_args_tuple(&call.args);
+    quote::quote!(thrust_models::model::closure_precondition(&(#func), #args)).into()
+}
+
+pub fn expand_post(input: TokenStream) -> TokenStream {
+    let parser = Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated;
+    let exprs = syn::parse_macro_input!(input with parser);
+    let exprs: Vec<syn::Expr> = exprs.into_iter().collect();
+    let [call_expr, result] = exprs.as_slice() else {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "post! expects `post!(f(args), result)`",
+        )
+        .to_compile_error()
+        .into();
+    };
+    let syn::Expr::Call(call) = call_expr else {
+        return syn::Error::new_spanned(
+            call_expr,
+            "post! expects a call expression as its first argument, e.g. `post!(f(x), r)`",
+        )
+        .to_compile_error()
+        .into();
+    };
+    let func = &*call.func;
+    let args = call_args_tuple(&call.args);
+    quote::quote!(thrust_models::model::closure_postcondition(&(#func), #args, #result)).into()
+}


### PR DESCRIPTION
Implements #71: allow `#[thrust_macros::requires]` / `#[thrust_macros::ensures]` specifications to refer to the precondition and postcondition of a closure parameter `f`. This enables specifying higher-order functions in terms of the contracts of the closures passed to them.

## Surface syntax

```rust
thrust_macros::pre!(f(x))         // f's precondition holds for argument x
thrust_macros::post!(f(x), r)     // r is a possible result of f(x)
```

Arity is handled automatically (`pre!(f())`, `pre!(f(x))`, `pre!(f(x, y))`), so there is no tuple noise. Example — `Option::map`:

```rust
#[requires(opt == None || exists(|i| opt == Some(i) && pre!(f(i))))]
#[ensures((opt == None && result == None)
       || exists(|i| exists(|j| opt == Some(i) && post!(f(i), j) && result == Some(j))))]
```

## What's included

- **std.rs**: marker functions `thrust_models::model::closure_precondition(&f, args)` and `closure_postcondition(&f, args, result)` (tagged `#[thrust::def::…]`), plus `Option::map` and `Option::unwrap_or_else` extern specs written with `pre!`/`post!`.
- **thrust-macros**: function-like macros `pre!` / `post!` (`pre_post.rs`) that desugar to those marker functions, tupling the call arguments. Pure surface sugar; the analyzer is unchanged.
- **analyze**: recognize the markers in the formula-function translator (`annot_fn`); resolve the referenced closure's `FunctionType` from the analyzer's already-known defs (`known_function_ty_with_args`), and expand a marker by substituting the supplied argument terms into the closure's parameter/return refinements.
- **rty**: `FunctionType::{precondition,postcondition}_formula` helpers — a positional substitution of parameter values into the closure's refinements (the closure value itself is the leading `RustCall` environment parameter).

## Tests

New pass/fail ui tests, all verifying non-vacuously:

- `closure_postcondition` (+ `closure_postcondition_generic`, exercised through a generic wrapper) — a higher-order `apply` using `pre!`/`post!`.
- `option_map`, `option_unwrap_or_else` — exercise the new std specs (use the PCSat solver, like the existing `annot_exists`/`iterators` tests).

`cargo test` passes (214 tests, with the PCSat/COAR solver available); `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

## Two commits

1. **Refer to closure pre-/post-conditions in specifications** — the marker functions, analyzer/`rty` support, std specs and tests (using the markers directly).
2. **Add pre!/post! sugar** — the `pre!`/`post!` macros, with std/tests switched to them.

## Scope and #83 compatibility

`pre!`/`post!` wrap a *call expression*, which is the shape #83 needs ("the pre/post of a call to some def"). This PR is deliberately scoped to **closures only** — the markers lower to a closure's `FunctionType`. When #83 generalizes this to other defs (e.g. #82's `<&T as PartialEq>::eq`), the user-facing `pre!`/`post!` syntax stays the same and only the lowering grows.

## Notes

- Builds on #105 (generic functions' bodies are verified against their contracts) and #108 (generic HOF with a generic-typed closure argument); both are in `main`.
- The std combinators are trusted `extern_spec_fn`s, so their specs surface the closure's precondition in `requires` (e.g. `requires(pre!(f(x)))`) so callers discharge it — otherwise a postcondition referring to that closure would be vacuous.

Closes #71

https://claude.ai/code/session_01NyPQne5pFDqo9g3rnpAUSS