### PR TITLE
Add UI tests for gcd behavior (pass and fail cases)

### DIFF
--- a/tests/ui/fail/gcd.rs
+++ b/tests/ui/fail/gcd.rs
@@ -1,0 +1,21 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -Adead_code -C debug-assertions=false
+
+fn gcd(mut a: i32, mut b: i32) -> i32 {
+    while a != b {
+        let (l, r) = if a < b {
+            (&mut a, &b)
+        } else {
+            (&mut b, &a)
+        };
+        *l -= *r;
+    }
+    a
+}
+
+#[thrust::callable]
+fn check_gcd(a: i32, b: i32) {
+    assert!(gcd(a, b) <= a);
+}
+
+fn main() {}

--- a/tests/ui/pass/gcd.rs
+++ b/tests/ui/pass/gcd.rs
@@ -1,0 +1,21 @@
+//@check-pass
+//@compile-flags: -Adead_code -C debug-assertions=false
+
+fn gcd(mut a: i32, mut b: i32) -> i32 {
+    while a != b {
+        let (l, r) = if a > b {
+            (&mut a, &b)
+        } else {
+            (&mut b, &a)
+        };
+        *l -= *r;
+    }
+    a
+}
+
+#[thrust::callable]
+fn check_gcd(a: i32, b: i32) {
+    assert!(gcd(a, b) <= a);
+}
+
+fn main() {}


### PR DESCRIPTION
### Motivation
- Add targeted UI tests to exercise the `gcd` implementation and the verifier's handling of the mutable/immutable reference pattern and branching differences that affect the verification outcome.

### Description
- Add `tests/ui/pass/gcd.rs` which contains a `gcd` implementation and a `#[thrust::callable]` check expecting the assertion to pass with `// @check-pass` and compile flags `-Adead_code -C debug-assertions=false`.
- Add `tests/ui/fail/gcd.rs` which contains a variant of the `gcd` implementation that is expected to produce a verification failure annotated with `// @error-in-other-file: Unsat` and the same compile flags.
- Both tests include the `check_gcd` function that asserts `gcd(a, b) <= a` to exercise the verifier on the different branch conditions.

### Testing
- Ran the repository UI test harness for the new cases and observed that `tests/ui/pass/gcd.rs` passed as annotated. 
- Observed that `tests/ui/fail/gcd.rs` produced the expected verification failure (`Unsat`) as annotated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26ebbf22c8832b84836b53e2f80fe6)