### PR TITLE
Support Rust syntax in thrust::predicate bodies

### DIFF
--- a/src/analyze/crate_.rs
+++ b/src/analyze/crate_.rs
@@ -83,13 +83,20 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                 self.skip_analysis.insert(*local_def_id);
                 keys.swap_remove(local_def_id);
             }
-            if analyzer.is_annotated_as_predicate() {
-                analyzer.analyze_predicate_definition();
-                self.skip_analysis.insert(*local_def_id);
-                keys.swap_remove(local_def_id);
-            }
-            if analyzer.is_annotated_as_formula_fn() {
-                self.ctx.register_formula_fn(*local_def_id);
+            let is_predicate = analyzer.is_annotated_as_predicate();
+            let is_formula_fn = analyzer.is_annotated_as_formula_fn();
+            if is_predicate || is_formula_fn {
+                // A predicate whose body is a Rust expression is also marked
+                // `formula_fn`; register it first so `analyze_predicate_definition`
+                // can pull the translated formula via `formula_fn_with_args`.
+                if is_formula_fn {
+                    self.ctx.register_formula_fn(*local_def_id);
+                }
+                if is_predicate {
+                    self.ctx
+                        .local_def_analyzer(*local_def_id)
+                        .analyze_predicate_definition();
+                }
                 self.skip_analysis.insert(*local_def_id);
                 keys.swap_remove(local_def_id);
             }

--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -60,6 +60,40 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     }
 
     fn define_as_predicate(&self, pred: chc::UserDefinedPred) {
+        let sig = self.ctx.fn_sig(self.local_def_id.to_def_id());
+        let arg_sorts = sig
+            .inputs()
+            .iter()
+            .map(|input_ty| self.type_builder.build(*input_ty).to_sort());
+
+        // A predicate marked `formula_fn` carries a Rust-expression body that has
+        // been translated into a `chc::Formula`; otherwise the body is a raw
+        // SMT-LIB2 string literal.
+        if self.is_annotated_as_formula_fn() {
+            // Name the parameters `v{i}` to match how `chc::TermVarIdx` renders the
+            // formula's variables (see `chc::UserDefinedPredBody::Formula`).
+            let arg_name_and_sorts = arg_sorts
+                .enumerate()
+                .map(|(i, sort)| (format!("v{i}"), sort))
+                .collect::<Vec<_>>();
+
+            let formula_fn = self
+                .ctx
+                .formula_fn_with_args(self.local_def_id, self.tcx.mk_args(&[]))
+                .expect("predicate formula function is not registered");
+            let formula = formula_fn
+                .formula()
+                .clone()
+                .map_var(|idx| chc::TermVarIdx::from(idx.index()));
+
+            self.ctx.system.borrow_mut().push_pred_define_formula(
+                pred,
+                chc::UserDefinedPredSig::from(arg_name_and_sorts),
+                formula,
+            );
+            return;
+        }
+
         // function's body
         use rustc_hir::{Block, Expr, ExprKind};
 
@@ -87,12 +121,6 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                     .name
                     .to_string()
             });
-
-        let sig = self.ctx.fn_sig(self.local_def_id.to_def_id());
-        let arg_sorts = sig
-            .inputs()
-            .iter()
-            .map(|input_ty| self.type_builder.build(*input_ty).to_sort());
 
         let arg_name_and_sorts = arg_names.into_iter().zip(arg_sorts).collect::<Vec<_>>();
 

--- a/src/chc.rs
+++ b/src/chc.rs
@@ -1918,9 +1918,32 @@ impl Clause {
     pub fn is_nop(&self) -> bool {
         self.head.is_top() || self.body.is_bottom()
     }
+}
+
+/// Resolves the sort of term-level variables.
+///
+/// Rendering a [`Term`] to SMT-LIB2 needs the sort of each variable, because
+/// box/mut/tuple constructors and selectors are sort-indexed. Anything that can
+/// provide variable sorts (a [`Clause`] via its `vars`, or a bare list of sorts
+/// for a `define-fun` signature) can drive term rendering through this trait,
+/// so callers need not fabricate a [`Clause`].
+pub trait TermSortEnv {
+    fn var_sort(&self, var: TermVarIdx) -> Sort;
 
     fn term_sort(&self, term: &Term<TermVarIdx>) -> Sort {
-        term.sort(|v| self.vars[*v].clone())
+        term.sort(|v| self.var_sort(*v))
+    }
+}
+
+impl TermSortEnv for Clause {
+    fn var_sort(&self, var: TermVarIdx) -> Sort {
+        self.vars[var].clone()
+    }
+}
+
+impl TermSortEnv for IndexVec<TermVarIdx, Sort> {
+    fn var_sort(&self, var: TermVarIdx) -> Sort {
+        self[var].clone()
     }
 }
 
@@ -1980,11 +2003,22 @@ pub struct PredVarDef {
 
 pub type UserDefinedPredSig = Vec<(String, Sort)>;
 
+/// The body of a user-defined predicate.
+///
+/// A predicate can be defined either by a raw SMT-LIB2 string (inserted into the
+/// generated `define-fun` verbatim) or by a [`Formula`] translated from a Rust
+/// expression via the `formula_fn` infrastructure.
+#[derive(Debug, Clone)]
+pub enum UserDefinedPredBody {
+    Raw(String),
+    Formula(Formula<TermVarIdx>),
+}
+
 #[derive(Debug, Clone)]
 pub struct UserDefinedPredDef {
     symbol: UserDefinedPred,
     sig: UserDefinedPredSig,
-    body: String,
+    body: UserDefinedPredBody,
 }
 
 /// A CHC system.
@@ -2012,8 +2046,24 @@ impl System {
         sig: UserDefinedPredSig,
         body: String,
     ) {
-        self.user_defined_pred_defs
-            .push(UserDefinedPredDef { symbol, sig, body })
+        self.user_defined_pred_defs.push(UserDefinedPredDef {
+            symbol,
+            sig,
+            body: UserDefinedPredBody::Raw(body),
+        })
+    }
+
+    pub fn push_pred_define_formula(
+        &mut self,
+        symbol: UserDefinedPred,
+        sig: UserDefinedPredSig,
+        formula: Formula<TermVarIdx>,
+    ) {
+        self.user_defined_pred_defs.push(UserDefinedPredDef {
+            symbol,
+            sig,
+            body: UserDefinedPredBody::Formula(formula),
+        })
     }
 
     pub fn push_clause(&mut self, clause: Clause) -> Option<ClauseId> {

--- a/src/chc/format_context.rs
+++ b/src/chc/format_context.rs
@@ -7,7 +7,7 @@
 
 use std::collections::BTreeSet;
 
-use crate::chc::{self, hoice::HoiceDatatypeRenamer};
+use crate::chc::{self, hoice::HoiceDatatypeRenamer, TermSortEnv as _};
 
 /// A context for formatting a CHC system.
 ///

--- a/src/chc/smtlib2.rs
+++ b/src/chc/smtlib2.rs
@@ -89,11 +89,11 @@ impl<T> List<T> {
 }
 
 /// A wrapper around a [`chc::Term`] that provides a [`std::fmt::Display`] implementation in SMT-LIB2 format.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct Term<'ctx, 'a> {
     ctx: &'ctx FormatContext,
-    // we need clause to select box/mut selector/constructor based on sort
-    clause: &'a chc::Clause,
+    // we need variable sorts to select box/mut selector/constructor
+    sorts: &'a dyn chc::TermSortEnv,
     inner: &'a chc::Term,
 }
 
@@ -106,49 +106,49 @@ impl<'ctx, 'a> std::fmt::Display for Term<'ctx, 'a> {
             chc::Term::Bool(b) => write!(f, "{}", b),
             chc::Term::String(s) => write!(f, "\"{}\"", s.escape_default()),
             chc::Term::Box(t) => {
-                let s = self.clause.term_sort(t);
+                let s = self.sorts.term_sort(t);
                 write!(
                     f,
                     "({} {})",
                     self.ctx.box_ctor(&s),
-                    Term::new(self.ctx, self.clause, t)
+                    Term::new(self.ctx, self.sorts, t)
                 )
             }
             chc::Term::Mut(t1, t2) => {
-                let s = self.clause.term_sort(t1);
+                let s = self.sorts.term_sort(t1);
                 write!(
                     f,
                     "({} {} {})",
                     self.ctx.mut_ctor(&s),
-                    Term::new(self.ctx, self.clause, t1),
-                    Term::new(self.ctx, self.clause, t2)
+                    Term::new(self.ctx, self.sorts, t1),
+                    Term::new(self.ctx, self.sorts, t2)
                 )
             }
             chc::Term::BoxCurrent(t) => {
-                let s = self.clause.term_sort(t).deref();
+                let s = self.sorts.term_sort(t).deref();
                 write!(
                     f,
                     "({} {})",
                     self.ctx.box_current(&s),
-                    Term::new(self.ctx, self.clause, t)
+                    Term::new(self.ctx, self.sorts, t)
                 )
             }
             chc::Term::MutCurrent(t) => {
-                let s = self.clause.term_sort(t).deref();
+                let s = self.sorts.term_sort(t).deref();
                 write!(
                     f,
                     "({} {})",
                     self.ctx.mut_current(&s),
-                    Term::new(self.ctx, self.clause, t)
+                    Term::new(self.ctx, self.sorts, t)
                 )
             }
             chc::Term::MutFinal(t) => {
-                let s = self.clause.term_sort(t).deref();
+                let s = self.sorts.term_sort(t).deref();
                 write!(
                     f,
                     "({} {})",
                     self.ctx.mut_final(&s),
-                    Term::new(self.ctx, self.clause, t)
+                    Term::new(self.ctx, self.sorts, t)
                 )
             }
             chc::Term::App(fn_, args) => {
@@ -156,7 +156,7 @@ impl<'ctx, 'a> std::fmt::Display for Term<'ctx, 'a> {
                     f,
                     "({} {})",
                     fn_,
-                    List::open(args.iter().map(|t| Term::new(self.ctx, self.clause, t)))
+                    List::open(args.iter().map(|t| Term::new(self.ctx, self.sorts, t)))
                 )
             }
             chc::Term::ArrayEmpty(index, elem) => {
@@ -166,7 +166,7 @@ impl<'ctx, 'a> std::fmt::Display for Term<'ctx, 'a> {
                 write!(
                     f,
                     "((as const (Array {index_sort} {elem_sort})) {})",
-                    Term::new(self.ctx, self.clause, &default)
+                    Term::new(self.ctx, self.sorts, &default)
                 )
             }
             chc::Term::SeqConcat(elem, t) => {
@@ -175,11 +175,11 @@ impl<'ctx, 'a> std::fmt::Display for Term<'ctx, 'a> {
                     f,
                     "({} {})",
                     name,
-                    List::open(t.iter_args().map(|t| Term::new(self.ctx, self.clause, t)))
+                    List::open(t.iter_args().map(|t| Term::new(self.ctx, self.sorts, t)))
                 )
             }
             chc::Term::Tuple(ts) => {
-                let ss: Vec<_> = ts.iter().map(|t| self.clause.term_sort(t)).collect();
+                let ss: Vec<_> = ts.iter().map(|t| self.sorts.term_sort(t)).collect();
                 if ss.is_empty() {
                     write!(f, "{}", self.ctx.tuple_ctor(&ss),)
                 } else {
@@ -187,17 +187,17 @@ impl<'ctx, 'a> std::fmt::Display for Term<'ctx, 'a> {
                         f,
                         "({} {})",
                         self.ctx.tuple_ctor(&ss),
-                        List::open(ts.iter().map(|t| Term::new(self.ctx, self.clause, t)))
+                        List::open(ts.iter().map(|t| Term::new(self.ctx, self.sorts, t)))
                     )
                 }
             }
             chc::Term::TupleProj(t, i) => {
-                let s = self.clause.term_sort(t);
+                let s = self.sorts.term_sort(t);
                 write!(
                     f,
                     "({} {})",
                     self.ctx.tuple_proj(s.as_tuple().unwrap(), *i),
-                    Term::new(self.ctx, self.clause, t)
+                    Term::new(self.ctx, self.sorts, t)
                 )
             }
             chc::Term::DatatypeCtor(sort, sym, args) => {
@@ -208,17 +208,17 @@ impl<'ctx, 'a> std::fmt::Display for Term<'ctx, 'a> {
                         f,
                         "({} {})",
                         self.ctx.datatype_ctor(sort, sym),
-                        List::open(args.iter().map(|t| Term::new(self.ctx, self.clause, t)))
+                        List::open(args.iter().map(|t| Term::new(self.ctx, self.sorts, t)))
                     )
                 }
             }
             chc::Term::DatatypeDiscr(_s, t) => {
-                let s = self.clause.term_sort(t).into_datatype().unwrap();
+                let s = self.sorts.term_sort(t).into_datatype().unwrap();
                 write!(
                     f,
                     "({} {})",
                     self.ctx.datatype_discr(&s),
-                    Term::new(self.ctx, self.clause, t)
+                    Term::new(self.ctx, self.sorts, t)
                 )
             }
             chc::Term::FormulaQuantifiedVar(_, name) => write!(f, "{}", name),
@@ -227,23 +227,27 @@ impl<'ctx, 'a> std::fmt::Display for Term<'ctx, 'a> {
 }
 
 impl<'ctx, 'a> Term<'ctx, 'a> {
-    pub fn new(ctx: &'ctx FormatContext, clause: &'a chc::Clause, inner: &'a chc::Term) -> Self {
-        Self { ctx, clause, inner }
+    pub fn new(
+        ctx: &'ctx FormatContext,
+        sorts: &'a dyn chc::TermSortEnv,
+        inner: &'a chc::Term,
+    ) -> Self {
+        Self { ctx, sorts, inner }
     }
 }
 
 /// A wrapper around a [`chc::Atom`] that provides a [`std::fmt::Display`] implementation in SMT-LIB2 format.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Atom<'ctx, 'a> {
     ctx: &'ctx FormatContext,
-    clause: &'a chc::Clause,
+    sorts: &'a dyn chc::TermSortEnv,
     inner: &'a chc::Atom,
 }
 
 impl<'ctx, 'a> std::fmt::Display for Atom<'ctx, 'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(guard) = &self.inner.guard {
-            let guard = Formula::new(self.ctx, self.clause, guard);
+            let guard = Formula::new(self.ctx, self.sorts, guard);
             write!(f, "(=> {} ", guard)?;
         }
         if self.inner.pred.is_negative() {
@@ -260,7 +264,7 @@ impl<'ctx, 'a> std::fmt::Display for Atom<'ctx, 'a> {
                 self.inner
                     .args
                     .iter()
-                    .map(|t| Term::new(self.ctx, self.clause, t)),
+                    .map(|t| Term::new(self.ctx, self.sorts, t)),
             );
             write!(f, "({} {})", pred, args)?;
         }
@@ -275,16 +279,20 @@ impl<'ctx, 'a> std::fmt::Display for Atom<'ctx, 'a> {
 }
 
 impl<'ctx, 'a> Atom<'ctx, 'a> {
-    pub fn new(ctx: &'ctx FormatContext, clause: &'a chc::Clause, inner: &'a chc::Atom) -> Self {
-        Self { ctx, clause, inner }
+    pub fn new(
+        ctx: &'ctx FormatContext,
+        sorts: &'a dyn chc::TermSortEnv,
+        inner: &'a chc::Atom,
+    ) -> Self {
+        Self { ctx, sorts, inner }
     }
 }
 
 /// A wrapper around a [`chc::Formula`] that provides a [`std::fmt::Display`] implementation in SMT-LIB2 format.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Formula<'ctx, 'a> {
     ctx: &'ctx FormatContext,
-    clause: &'a chc::Clause,
+    sorts: &'a dyn chc::TermSortEnv,
     inner: &'a chc::Formula,
 }
 
@@ -292,24 +300,24 @@ impl<'ctx, 'a> std::fmt::Display for Formula<'ctx, 'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.inner {
             chc::Formula::Atom(atom) => {
-                let atom = Atom::new(self.ctx, self.clause, atom);
+                let atom = Atom::new(self.ctx, self.sorts, atom);
                 write!(f, "{}", atom)
             }
             chc::Formula::Not(fo) => {
-                let fo = Formula::new(self.ctx, self.clause, fo);
+                let fo = Formula::new(self.ctx, self.sorts, fo);
                 write!(f, "(not {})", fo)
             }
             chc::Formula::And(fs) => {
-                let fs = List::open(fs.iter().map(|fo| Formula::new(self.ctx, self.clause, fo)));
+                let fs = List::open(fs.iter().map(|fo| Formula::new(self.ctx, self.sorts, fo)));
                 write!(f, "(and {})", fs)
             }
             chc::Formula::Or(fs) => {
-                let fs = List::open(fs.iter().map(|fo| Formula::new(self.ctx, self.clause, fo)));
+                let fs = List::open(fs.iter().map(|fo| Formula::new(self.ctx, self.sorts, fo)));
                 write!(f, "(or {})", fs)
             }
             chc::Formula::Implies(lhs, rhs) => {
-                let lhs = Formula::new(self.ctx, self.clause, lhs);
-                let rhs = Formula::new(self.ctx, self.clause, rhs);
+                let lhs = Formula::new(self.ctx, self.sorts, lhs);
+                let rhs = Formula::new(self.ctx, self.sorts, rhs);
                 write!(f, "(=> {lhs} {rhs})")
             }
             chc::Formula::Exists(vars, fo) => {
@@ -317,7 +325,7 @@ impl<'ctx, 'a> std::fmt::Display for Formula<'ctx, 'a> {
                     List::closed(vars.iter().map(|(v, s)| {
                         List::closed([v.to_string(), self.ctx.fmt_sort(s).to_string()])
                     }));
-                let fo = Formula::new(self.ctx, self.clause, fo);
+                let fo = Formula::new(self.ctx, self.sorts, fo);
                 write!(f, "(exists {vars} {fo})")
             }
             chc::Formula::Forall(vars, fo) => {
@@ -325,7 +333,7 @@ impl<'ctx, 'a> std::fmt::Display for Formula<'ctx, 'a> {
                     List::closed(vars.iter().map(|(v, s)| {
                         List::closed([v.to_string(), self.ctx.fmt_sort(s).to_string()])
                     }));
-                let fo = Formula::new(self.ctx, self.clause, fo);
+                let fo = Formula::new(self.ctx, self.sorts, fo);
                 write!(f, "(forall {vars} {fo})")
             }
         }
@@ -333,16 +341,20 @@ impl<'ctx, 'a> std::fmt::Display for Formula<'ctx, 'a> {
 }
 
 impl<'ctx, 'a> Formula<'ctx, 'a> {
-    pub fn new(ctx: &'ctx FormatContext, clause: &'a chc::Clause, inner: &'a chc::Formula) -> Self {
-        Self { ctx, clause, inner }
+    pub fn new(
+        ctx: &'ctx FormatContext,
+        sorts: &'a dyn chc::TermSortEnv,
+        inner: &'a chc::Formula,
+    ) -> Self {
+        Self { ctx, sorts, inner }
     }
 }
 
 /// A wrapper around a [`chc::Body`] that provides a [`std::fmt::Display`] implementation in SMT-LIB2 format.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Body<'ctx, 'a> {
     ctx: &'ctx FormatContext,
-    clause: &'a chc::Clause,
+    sorts: &'a dyn chc::TermSortEnv,
     inner: &'a chc::Body,
 }
 
@@ -352,16 +364,20 @@ impl<'ctx, 'a> std::fmt::Display for Body<'ctx, 'a> {
             self.inner
                 .atoms
                 .iter()
-                .map(|a| Atom::new(self.ctx, self.clause, a)),
+                .map(|a| Atom::new(self.ctx, self.sorts, a)),
         );
-        let formula = Formula::new(self.ctx, self.clause, &self.inner.formula);
+        let formula = Formula::new(self.ctx, self.sorts, &self.inner.formula);
         write!(f, "(and {atoms} {formula})")
     }
 }
 
 impl<'ctx, 'a> Body<'ctx, 'a> {
-    pub fn new(ctx: &'ctx FormatContext, clause: &'a chc::Clause, inner: &'a chc::Body) -> Self {
-        Self { ctx, clause, inner }
+    pub fn new(
+        ctx: &'ctx FormatContext,
+        sorts: &'a dyn chc::TermSortEnv,
+        inner: &'a chc::Body,
+    ) -> Self {
+        Self { ctx, sorts, inner }
     }
 }
 
@@ -609,10 +625,27 @@ impl<'ctx, 'a> std::fmt::Display for UserDefinedPredDef<'ctx, 'a> {
         );
         write!(
             f,
-            "(define-fun {name} {params} Bool {body})",
+            "(define-fun {name} {params} Bool ",
             name = self.inner.symbol,
-            body = &self.inner.body,
-        )
+        )?;
+        match &self.inner.body {
+            chc::UserDefinedPredBody::Raw(body) => write!(f, "{body}")?,
+            chc::UserDefinedPredBody::Formula(formula) => {
+                // Term display resolves variable sorts (for box/mut/tuple
+                // constructors) through a `TermSortEnv`: here, the predicate's
+                // parameter sorts in order. The formula's `Var(v{i})` and the
+                // `(v{i} Sort)` parameter list above both render via `TermVarIdx`,
+                // so they line up by index.
+                let sorts: rustc_index::IndexVec<chc::TermVarIdx, chc::Sort> = self
+                    .inner
+                    .sig
+                    .iter()
+                    .map(|(_, sort)| sort.clone())
+                    .collect();
+                write!(f, "{}", Formula::new(self.ctx, &sorts, formula))?;
+            }
+        }
+        write!(f, ")")
     }
 }
 

--- a/src/chc/unbox.rs
+++ b/src/chc/unbox.rs
@@ -177,6 +177,12 @@ fn unbox_user_defined_pred_def(user_defined_pred_def: UserDefinedPredDef) -> Use
         .into_iter()
         .map(|(name, sort)| (name, unbox_sort(sort)))
         .collect();
+    let body = match body {
+        UserDefinedPredBody::Raw(s) => UserDefinedPredBody::Raw(s),
+        UserDefinedPredBody::Formula(formula) => {
+            UserDefinedPredBody::Formula(unbox_formula(formula))
+        }
+    };
     UserDefinedPredDef { symbol, sig, body }
 }
 

--- a/tests/ui/fail/annot_preds.rs
+++ b/tests/ui/fail/annot_preds.rs
@@ -1,12 +1,9 @@
 //@error-in-other-file: Unsat
 //@compile-flags: -Adead_code -C debug-assertions=off
 
-#[thrust::predicate]
-fn is_double(x: thrust_models::model::Int, doubled_x: thrust_models::model::Int) -> bool {
-    "(=
-        (* x 2)
-        doubled_x
-    )"; true
+#[thrust_macros::predicate]
+fn is_double(x: i64, doubled_x: i64) -> bool {
+    x * 2 == doubled_x
 }
 
 #[thrust_macros::requires(true)]

--- a/tests/ui/fail/annot_preds_trait.rs
+++ b/tests/ui/fail/annot_preds_trait.rs
@@ -25,15 +25,10 @@ trait Double {
 
 #[thrust_macros::context]
 impl Double for A {
-    // Write concrete definitions for predicates in `impl` blocks
+    // self.x * 3 (this isn't actually doubled!) does not comply with the trait.
     #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
-        // (tuple_proj<Int>.0 self) is equivalent to self.x
-        // self.x * 3 == doubled.x (this isn't actually doubled!) is written as following:
-        "(=
-            (* (tuple_proj<Int>.0 self_) 3)
-            (tuple_proj<Int>.0 doubled)
-        )"; true // This definition does not comply with annotations in trait!
+        self.x * 3 == doubled.x
     }
 
     // Check if this method complies with annotations in

--- a/tests/ui/fail/annot_preds_trait_multi.rs
+++ b/tests/ui/fail/annot_preds_trait_multi.rs
@@ -26,11 +26,7 @@ impl thrust_models::Model for A {
 impl Double for A {
     #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
-        // self.x * 2 == doubled.x
-        "(=
-            (* (tuple_proj<Int>.0 self_) 2)
-            (tuple_proj<Int>.0 doubled)
-        )"; true
+        self.x * 2 == doubled.x
     }
 
     fn double(&mut self) {
@@ -50,19 +46,10 @@ impl thrust_models::Model for B {
 
 #[thrust_macros::context]
 impl Double for B {
+    // self.x * 3 (this isn't actually doubled!) does not comply with the trait.
     #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
-        // self.x * 3 == doubled.x && self.y * 2 == doubled.y (this isn't actually doubled!)
-        "(and
-            (=
-                (* (tuple_proj<Int-Int>.0 self_) 3)
-                (tuple_proj<Int-Int>.0 doubled)
-            )
-            (=
-                (* (tuple_proj<Int-Int>.1 self_) 2)
-                (tuple_proj<Int-Int>.1 doubled)
-            )
-        )"; true // This definition does not comply with annotations in trait!
+        self.x * 3 == doubled.x && self.y * 2 == doubled.y
     }
 
     fn double(&mut self) {

--- a/tests/ui/pass/annot_preds.rs
+++ b/tests/ui/pass/annot_preds.rs
@@ -1,12 +1,9 @@
 //@check-pass
 //@compile-flags: -Adead_code -C debug-assertions=off
 
-#[thrust::predicate]
-fn is_double(x: thrust_models::model::Int, doubled_x: thrust_models::model::Int) -> bool {
-    "(=
-        (* x 2)
-        doubled_x
-    )"; true
+#[thrust_macros::predicate]
+fn is_double(x: i64, doubled_x: i64) -> bool {
+    x * 2 == doubled_x
 }
 
 #[thrust_macros::requires(true)]

--- a/tests/ui/pass/annot_preds_trait.rs
+++ b/tests/ui/pass/annot_preds_trait.rs
@@ -25,15 +25,10 @@ trait Double {
 
 #[thrust_macros::context]
 impl Double for A {
-    // Write concrete definitions for predicates in `impl` blocks
+    // Write concrete definitions for predicates in `impl` blocks, in Rust syntax.
     #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
-        // (tuple_proj<Int>.0 self) is equivalent to self.x
-        // self.x * 2 == doubled.x is written as following:
-        "(=
-            (* (tuple_proj<Int>.0 self_) 2)
-            (tuple_proj<Int>.0 doubled)
-        )"; true
+        self.x * 2 == doubled.x
     }
 
     // Check if this method complies with annotations in

--- a/tests/ui/pass/annot_preds_trait_multi.rs
+++ b/tests/ui/pass/annot_preds_trait_multi.rs
@@ -26,11 +26,7 @@ impl thrust_models::Model for A {
 impl Double for A {
     #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
-        // self.x * 2 == doubled.x
-        "(=
-            (* (tuple_proj<Int>.0 self_) 2)
-            (tuple_proj<Int>.0 doubled)
-        )"; true
+        self.x * 2 == doubled.x
     }
 
     fn double(&mut self) {
@@ -52,17 +48,7 @@ impl thrust_models::Model for B {
 impl Double for B {
     #[thrust_macros::predicate]
     fn is_double(self, doubled: Self) -> bool {
-        // self.x * 2 == doubled.x && self.y * 2 == doubled.y
-        "(and
-            (=
-                (* (tuple_proj<Int-Int>.0 self_) 2)
-                (tuple_proj<Int-Int>.0 doubled)
-            )
-            (=
-                (* (tuple_proj<Int-Int>.1 self_) 2)
-                (tuple_proj<Int-Int>.1 doubled)
-            )
-        )"; true
+        self.x * 2 == doubled.x && self.y * 2 == doubled.y
     }
 
     fn double(&mut self) {

--- a/thrust-macros/src/spec.rs
+++ b/thrust-macros/src/spec.rs
@@ -41,16 +41,53 @@ pub fn expand_predicate(item: TokenStream) -> TokenStream {
     let model_preds = type_lowering.model_where_predicates();
     let extended_where = extended_where_clause(&func, &model_preds);
 
+    // A predicate body written as a Rust expression is translated through the
+    // `formula_fn` pipeline; a raw SMT-LIB2 string-literal body is not.
+    let is_rust_body = func.block().is_some_and(|block| !is_raw_smt2_body(block));
+    let formula_fn_attr = if is_rust_body {
+        quote! {
+            #[thrust::formula_fn]
+            #[allow(unused_variables)]
+            #[allow(non_snake_case)]
+        }
+    } else {
+        quote!()
+    };
+
     let sig = quote! {
         #[allow(dead_code)]
+        #formula_fn_attr
         #[thrust::predicate]
         fn #name #def_generics(#model_ty_params) -> #model_ret #extended_where
     };
     if let Some(block) = func.block() {
+        let mut block = block.clone();
+        // The receiver `self` is lowered to a named `self_` parameter, so rewrite
+        // references in the (Rust) body to match.
+        if is_rust_body {
+            rewrite_self_in_block(&mut block);
+        }
         quote! { #sig #block }.into()
     } else {
         quote! { #sig; }.into()
     }
+}
+
+/// Whether a predicate body is a raw SMT-LIB2 definition, i.e. it contains a
+/// string-literal statement such as `"(= ..)"; true`.
+fn is_raw_smt2_body(block: &syn::Block) -> bool {
+    block.stmts.iter().any(|stmt| {
+        matches!(
+            stmt,
+            syn::Stmt::Expr(
+                syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(_),
+                    ..
+                }),
+                _,
+            )
+        )
+    })
 }
 
 pub fn expand_requires(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -483,29 +520,34 @@ fn mentions_self(sig: &syn::Signature) -> bool {
     visitor.mentions_self
 }
 
-fn rewrite_self_in_expr(expr: &mut syn::Expr) {
-    struct Visitor;
+struct RewriteSelf;
 
-    impl syn::visit_mut::VisitMut for Visitor {
-        fn visit_ident_mut(&mut self, ident: &mut syn::Ident) {
-            if ident == "self" {
-                *ident = format_ident!("self_");
-            }
-        }
-
-        // syn skips macro token streams, so rewrite `self` inside the
-        // `formula!(..)` wrapper by hand.
-        fn visit_macro_mut(&mut self, mac: &mut syn::Macro) {
-            let self_ = format_ident!("self_");
-            mac.tokens = std::mem::take(&mut mac.tokens)
-                .into_iter()
-                .map(|tt| rewrite_self_in_tokens(tt, &self_))
-                .collect();
+impl syn::visit_mut::VisitMut for RewriteSelf {
+    fn visit_ident_mut(&mut self, ident: &mut syn::Ident) {
+        if ident == "self" {
+            *ident = format_ident!("self_");
         }
     }
 
+    // syn skips macro token streams, so rewrite `self` inside the
+    // `formula!(..)` wrapper by hand.
+    fn visit_macro_mut(&mut self, mac: &mut syn::Macro) {
+        let self_ = format_ident!("self_");
+        mac.tokens = std::mem::take(&mut mac.tokens)
+            .into_iter()
+            .map(|tt| rewrite_self_in_tokens(tt, &self_))
+            .collect();
+    }
+}
+
+fn rewrite_self_in_expr(expr: &mut syn::Expr) {
     use syn::visit_mut::VisitMut as _;
-    Visitor.visit_expr_mut(expr);
+    RewriteSelf.visit_expr_mut(expr);
+}
+
+fn rewrite_self_in_block(block: &mut syn::Block) {
+    use syn::visit_mut::VisitMut as _;
+    RewriteSelf.visit_block_mut(block);
 }
 
 /// Replaces a `self` identifier with `self_`, recursing into groups. Operates on


### PR DESCRIPTION
## Summary

`#[thrust::predicate]` bodies can now be written as ordinary Rust boolean expressions instead of raw SMT-LIB2 string literals, reusing the existing `formula_fn` translation pipeline (`AnnotFnTranslator`).

```rust
// before — raw SMT2
#[thrust_macros::predicate]
fn is_double(self, doubled: Self) -> bool {
    "(= (* (tuple_proj<Int>.0 self_) 2) (tuple_proj<Int>.0 doubled))"; true
}

// after — Rust syntax
#[thrust_macros::predicate]
fn is_double(self, doubled: Self) -> bool {
    self.x * 2 == doubled.x
}
```

Raw SMT2 string bodies still work unchanged (backward compatible).

## How it works

A predicate written with `#[thrust_macros::predicate]` whose body is a Rust expression is expanded with an additional `#[thrust::formula_fn]` attribute, which is the single discriminator:

- **present** ⇒ the body is interpreted by `AnnotFnTranslator` through the existing `formula_fns` cache (`formula_fn_with_args`), exactly like `requires`/`ensures`/`invariant`. The resulting `chc::Formula` is emitted as the predicate's SMT `define-fun`.
- **absent** ⇒ the legacy raw-SMT2 string path (unchanged).

The macro picks which by inspecting the body (string-literal statement ⇒ raw; otherwise Rust). Borrow-check skipping is free, since `mir_borrowck_skip_formula_fn` already keys on the `formula_fn` attribute. Predicate call sites are still resolved as named `UserDefinedPred` atoms.

## Changes

- **`chc.rs`** — `UserDefinedPredDef` body becomes a `UserDefinedPredBody { Raw, Formula }` enum; add `push_pred_define_formula`. New `TermSortEnv` trait (`var_sort`/`term_sort`), implemented for `Clause` and `IndexVec<TermVarIdx, Sort>`.
- **`chc/smtlib2.rs`** — the `Term`/`Atom`/`Formula`/`Body` Display wrappers now hold `&dyn TermSortEnv` instead of `&Clause`. A `Formula` predicate body is rendered by passing the sig's sorts as an `IndexVec` — **no synthetic/fake `Clause`** is fabricated.
- **`chc/format_context.rs`** — uses the `TermSortEnv` trait (moved `Clause::term_sort` onto it).
- **`chc/unbox.rs`** — unbox `Formula` predicate bodies.
- **`analyze/crate_.rs`** — register predicate items also marked `formula_fn`.
- **`analyze/local_def.rs`** — `define_as_predicate` branches on the `formula_fn` attribute; pulls the formula from `formula_fn_with_args`, naming params `v{i}`.
- **`thrust-macros/src/spec.rs`** — `expand_predicate`: detect raw-vs-Rust body; for Rust bodies add `#[thrust::formula_fn]`, rewrite `self`→`self_`, add allow-attrs.
- **tests** — scalar (`annot_preds`), trait (`annot_preds_trait`), and multi-field (`annot_preds_trait_multi`) predicate tests (pass + fail) converted to Rust syntax.

## Dependency

Named struct-field access (`self.x`) in the trait/multi-field predicates relies on **#118 (merged)**, which taught the formula translator to resolve named ADT fields.

## Notes

- Rebased onto the latest `main` (single feature commit).
- **Verification** (local, z3 4.13.0 + docker pcsat): the full ui suite passes except `iterators/fixed_filter_loop_none.rs`, which returns solver `unknown` on z3 4.13.0. That failure is **pre-existing and unrelated** — it reproduces identically on `main` at the rebase base with the same z3, and `main` pins z3 to **4.15.4** (#149) precisely to avoid such solver-version issues. CI runs 4.15.4.
- Inspected the generated SMT2: `self.x * 2 == doubled.x` lowers to exactly `(= (* (tuple_proj<Int>.0 v0) 2) (tuple_proj<Int>.0 v1))` — identical to the previous raw form.

https://claude.ai/code/session_01WdLyxyy4ieAxrexj83X5MX