### PR TITLE
Resolve named struct fields in formula translation

### DIFF
--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -529,11 +529,22 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
                 FormulaOrTerm::Term(chc::Term::tuple(terms))
             }
             ExprKind::Field(expr, field) => {
-                let index = field
-                    .name
-                    .as_str()
-                    .parse::<usize>()
-                    .expect("tuple field index must be a non-negative integer");
+                // Tuples use numeric field names (`.0`); structs (represented as
+                // tuples in the logic) use named fields resolved to their position.
+                let index = match field.name.as_str().parse::<usize>() {
+                    Ok(index) => index,
+                    Err(_) => {
+                        let adt = self
+                            .expr_ty(expr)
+                            .ty_adt_def()
+                            .expect("named field access on a non-ADT type");
+                        adt.non_enum_variant()
+                            .fields
+                            .iter()
+                            .position(|f| f.name == field.name)
+                            .expect("unknown named field in formula")
+                    }
+                };
                 let term = self.to_term(expr);
                 FormulaOrTerm::Term(term.tuple_proj(index))
             }

--- a/tests/ui/fail/formula_struct_field.rs
+++ b/tests/ui/fail/formula_struct_field.rs
@@ -1,0 +1,27 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -Adead_code -C debug-assertions=off
+
+// P is represented as Tuple<Int, Int> in SMT-LIB2 format; fields are accessed
+// by name in the specification formula.
+#[derive(PartialEq)]
+struct P {
+    x: i64,
+    y: i64,
+}
+
+impl thrust_models::Model for P {
+    type Ty = Self;
+}
+
+// The postcondition claims the fields are unchanged, but `swap` swaps them.
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(result.x == p.x && result.y == p.y)]
+fn swap(p: P) -> P {
+    P { x: p.y, y: p.x }
+}
+
+fn main() {
+    let p = P { x: 3, y: 5 };
+    let q = swap(p);
+    assert!(q.x == 5 && q.y == 3);
+}

--- a/tests/ui/fail/formula_struct_field.rs
+++ b/tests/ui/fail/formula_struct_field.rs
@@ -1,8 +1,6 @@
 //@error-in-other-file: Unsat
 //@compile-flags: -Adead_code -C debug-assertions=off
 
-// P is represented as Tuple<Int, Int> in SMT-LIB2 format; fields are accessed
-// by name in the specification formula.
 #[derive(PartialEq)]
 struct P {
     x: i64,
@@ -13,7 +11,6 @@ impl thrust_models::Model for P {
     type Ty = Self;
 }
 
-// The postcondition claims the fields are unchanged, but `swap` swaps them.
 #[thrust_macros::requires(true)]
 #[thrust_macros::ensures(result.x == p.x && result.y == p.y)]
 fn swap(p: P) -> P {

--- a/tests/ui/pass/formula_struct_field.rs
+++ b/tests/ui/pass/formula_struct_field.rs
@@ -1,0 +1,26 @@
+//@check-pass
+//@compile-flags: -Adead_code -C debug-assertions=off
+
+// P is represented as Tuple<Int, Int> in SMT-LIB2 format; fields are accessed
+// by name in the specification formula.
+#[derive(PartialEq)]
+struct P {
+    x: i64,
+    y: i64,
+}
+
+impl thrust_models::Model for P {
+    type Ty = Self;
+}
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(result.x == p.y && result.y == p.x)]
+fn swap(p: P) -> P {
+    P { x: p.y, y: p.x }
+}
+
+fn main() {
+    let p = P { x: 3, y: 5 };
+    let q = swap(p);
+    assert!(q.x == 5 && q.y == 3);
+}

--- a/tests/ui/pass/formula_struct_field.rs
+++ b/tests/ui/pass/formula_struct_field.rs
@@ -1,8 +1,6 @@
 //@check-pass
 //@compile-flags: -Adead_code -C debug-assertions=off
 
-// P is represented as Tuple<Int, Int> in SMT-LIB2 format; fields are accessed
-// by name in the specification formula.
 #[derive(PartialEq)]
 struct P {
     x: i64,


### PR DESCRIPTION
## Summary

The formula translator (`AnnotFnTranslator`, used by `requires`/`ensures`/`invariant`/predicates) handled `ExprKind::Field` only for **numeric** tuple field names (`.0`, `.1`). Structs are represented as tuples in the logic, so accessing a named field — e.g. `result.x` in an `ensures` formula — panicked with `tuple field index must be a non-negative integer`.

This resolves a named field to its position in the ADT's (single, non-enum) variant, producing the same tuple-projection term as the numeric path. Numeric tuple indices keep their fast path.

```rust
#[ensures(result.x == p.y && result.y == p.x)]   // now works
fn swap(p: P) -> P { P { x: p.y, y: p.x } }
```

## Change

- `src/analyze/annot_fn.rs` — `ExprKind::Field`: when the field name isn't a numeric index, look up the field position via `expr_ty().ty_adt_def()`'s non-enum variant.

## Tests

- `tests/ui/{pass,fail}/formula_struct_field.rs` — an `ensures` formula referring to struct fields by name (pass = correct postcondition for `swap`; fail = postcondition violated).

## Context

Extracted from the `thrust::predicate` Rust-syntax work (PR #114) as an independent, self-contained improvement to the formula translator. PR #114's trait/struct predicate tests depend on this.

https://claude.ai/code/session_01WdLyxyy4ieAxrexj83X5MX

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdLyxyy4ieAxrexj83X5MX)_