### PR TITLE
Fix E0401 for invariant_context on trait methods

### DIFF
--- a/tests/ui/fail/loop_invariant_trait.rs
+++ b/tests/ui/fail/loop_invariant_trait.rs
@@ -1,0 +1,30 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand() -> i64 { unimplemented!() }
+
+#[thrust_macros::context]
+trait Foo {
+    #[thrust_macros::invariant_context]
+    fn run(&mut self) {
+        let mut x: i64 = 0;
+        while rand() == 0 {
+            thrust_macros::invariant!(|x: i64| x >= 1);
+            x += 1;
+        }
+        assert!(x >= 0);
+    }
+}
+
+struct Bar;
+impl thrust_models::Model for Bar {
+    type Ty = ();
+}
+impl Foo for Bar {}
+
+fn main() {
+    Bar.run();
+}

--- a/tests/ui/pass/loop_invariant_trait.rs
+++ b/tests/ui/pass/loop_invariant_trait.rs
@@ -1,0 +1,30 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand() -> i64 { unimplemented!() }
+
+#[thrust_macros::context]
+trait Foo {
+    #[thrust_macros::invariant_context]
+    fn run(&mut self) {
+        let mut x: i64 = 0;
+        while rand() == 0 {
+            thrust_macros::invariant!(|x: i64| x >= 0);
+            x += 1;
+        }
+        assert!(x >= 0);
+    }
+}
+
+struct Bar;
+impl thrust_models::Model for Bar {
+    type Ty = ();
+}
+impl Foo for Bar {}
+
+fn main() {
+    Bar.run();
+}

--- a/thrust-macros/src/invariant.rs
+++ b/thrust-macros/src/invariant.rs
@@ -177,7 +177,11 @@ fn expand_invariant(
     }
     rewriter.visit_expr_mut(&mut body);
 
-    if crate::tokens_contain_ident(&closure.to_token_stream(), "Self") {
+    let self_used = crate::tokens_contain_ident(&closure.to_token_stream(), "Self")
+        || def_wheres
+            .iter()
+            .any(|pred| crate::tokens_contain_ident(&pred.to_token_stream(), "Self"));
+    if self_used {
         let Some(outer) = context.and_then(|context| context.outer.as_ref()) else {
             return Err(syn::Error::new_spanned(
                 closure,


### PR DESCRIPTION

`#[thrust_macros::invariant_context]` attached to a **trait** method fails to compile with **E0401** ("can't use `Self` from outer item"):

```rust
#[thrust_macros::context]
trait Foo {
    #[thrust_macros::invariant_context]
    fn run(&mut self) {
        let mut x: i64 = 0;
        while x < 1 {
            thrust_macros::invariant!(|x: i64| x >= 0);
            x += 1;
        }
    }
}
```

## Root cause

`invariant_context` rewrites each inner `invariant!` into a free-standing `#[thrust::formula_fn]` nested inside the method body. Inside that nested item, `Self` is out of scope, so any `Self` reaching it is rejected with E0401.

The macro already re-binds `Self` to a synthetic generic (`__ThrustSelf`, instantiated with the real `Self` via turbofish) — but it only did so when the **closure** mentioned `Self`. On a trait method, `Self` also reaches the generated function's `where`-clause through two paths that were never rewritten:

1. the host signature's own bounds (e.g. `where Self: Sized`), and
2. the `Self: Model` / `<Self as Model>::Ty: PartialEq` bounds a `trait` outer context contributes through `model_where_predicates()`.

So for `|x: i64| x >= 0` (no `Self` in the closure) those predicate-borne `Self`s leaked through unbound. (The trait + `Self`-in-closure case was broken the same way.)

https://claude.ai/code/session_01UvhtewjXmse6vpHq7BJ81S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvhtewjXmse6vpHq7BJ81S)_