### PR TITLE
Support the receiver self in loop invariants

### DIFF
--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -983,6 +983,13 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         let mut mapping: Vec<rty::FunctionParamIdx> = Vec::with_capacity(idents.len());
         for ident in idents {
             let name = ident.expect("invariant parameters must be named").name;
+            // The synthetic `__thrust_self` parameter (emitted when an invariant refers to the receiver
+            // `self`) maps to the loop-carried receiver, which appears as `self` in debug info.
+            let name = if name.as_str() == "__thrust_self" {
+                rustc_span::Symbol::intern("self")
+            } else {
+                name
+            };
             let local = self.local_of_name_in_bb(name, bty).unwrap_or_else(|| {
                 self.tcx.dcx().fatal(format!(
                     "loop invariant refers to `{name}`, which is not a live variable at the loop header"

--- a/tests/ui/fail/loop_invariant_self_receiver.rs
+++ b/tests/ui/fail/loop_invariant_self_receiver.rs
@@ -1,0 +1,35 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand() -> bool { unimplemented!() }
+
+#[derive(PartialEq, Clone, Copy)]
+struct Counter {
+    value: i64,
+}
+
+impl thrust_models::Model for Counter {
+    type Ty = Counter;
+}
+
+#[thrust_macros::context]
+impl Counter {
+    #[thrust_macros::invariant_context]
+    fn run(&mut self) -> i64 {
+        let init = *self;
+        while rand() {
+            thrust_macros::invariant!(|init: Self, self: &mut Self| init.value <= (*self).value);
+            self.value -= 1;
+        }
+        init.value
+    }
+}
+
+fn main() {
+    let mut c = Counter { value: 3 };
+    c.run();
+}

--- a/tests/ui/pass/loop_invariant_self_receiver.rs
+++ b/tests/ui/pass/loop_invariant_self_receiver.rs
@@ -1,0 +1,35 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand() -> bool { unimplemented!() }
+
+#[derive(PartialEq, Clone, Copy)]
+struct Counter {
+    value: i64,
+}
+
+impl thrust_models::Model for Counter {
+    type Ty = Counter;
+}
+
+#[thrust_macros::context]
+impl Counter {
+    #[thrust_macros::invariant_context]
+    fn run(&mut self) -> i64 {
+        let init = *self;
+        while rand() {
+            thrust_macros::invariant!(|init: Self, self: &mut Self| init.value <= (*self).value);
+            self.value += 1;
+        }
+        init.value
+    }
+}
+
+fn main() {
+    let mut c = Counter { value: 3 };
+    c.run();
+}

--- a/thrust-macros/src/invariant.rs
+++ b/thrust-macros/src/invariant.rs
@@ -177,40 +177,66 @@ fn expand_invariant(
     }
     rewriter.visit_expr_mut(&mut body);
 
-    // `Self` in a method context: rewrite it to a synthetic generic everywhere
-    // it reaches the formula function — parameters, body, and the propagated
-    // where-clause predicates — then pass the real `Self` via turbofish (legal
-    // in expression position).
     if crate::tokens_contain_ident(&closure.to_token_stream(), "Self") {
-        let synth: syn::Ident = format_ident!("__ThrustSelf");
-        def_wheres.push(syn::parse_quote!(#synth: ?Sized));
+        let Some(outer) = context.and_then(|context| context.outer.as_ref()) else {
+            return Err(syn::Error::new_spanned(
+                closure,
+                "invariant closure cannot refer to `Self` without an enclosing impl/trait context",
+            ));
+        };
 
-        let mut rewriter = SelfRewriter { synth: &synth };
-        for param in &mut fn_params {
-            rewriter.visit_fn_arg_mut(param);
-        }
-        rewriter.visit_expr_mut(&mut body);
-        for pred in &mut def_wheres {
-            rewriter.visit_where_predicate_mut(pred);
-        }
-        def_params.push(quote!(#synth));
-        def_wheres.extend(type_lowering.model_where_predicates_for(&synth));
-        // Mirror the host's implicit `Self: Trait` bound onto the synthetic
-        // generic so trait associated types (`Self::Item`) and predicates
-        // (`Self::step`) remain resolvable on it.
-        if let Some(FnOuterItem::ItemTrait(item_trait)) =
-            context.and_then(|context| context.outer.as_ref())
-        {
-            let trait_ident = &item_trait.ident;
-            let (_, ty_generics, _) = item_trait.generics.split_for_impl();
-            def_wheres.push(syn::parse_quote!(#synth: #trait_ident #ty_generics));
-        }
-        turbofish_args.push(quote!(Self));
+        match outer {
+            FnOuterItem::ItemImpl(item_impl) => {
+                // `Self` in an impl method context: rewrite it to the concrete self type everywhere
+                // TODO: Support generic/trait impl
+                let self_ty = &item_impl.self_ty;
+                let mut rewriter = SelfTypeRewriter {
+                    to: *self_ty.clone(),
+                };
+                for param in &mut fn_params {
+                    rewriter.visit_fn_arg_mut(param);
+                }
+                rewriter.visit_expr_mut(&mut body);
+                for pred in &mut def_wheres {
+                    rewriter.visit_where_predicate_mut(pred);
+                }
+            }
+            FnOuterItem::ItemTrait(item_trait) => {
+                // `Self` in a trait method context: rewrite it to a synthetic generic everywhere
+                // it reaches the formula function — parameters, body, and the propagated
+                // where-clause predicates — then pass the real `Self` via turbofish (legal
+                // in expression position).
+                let synth: syn::Ident = format_ident!("__ThrustSelf");
+                def_wheres.push(syn::parse_quote!(#synth: ?Sized));
 
-        // Rewriting `Self` to the synthetic generic can yield predicates that
-        // duplicate the synthetic generic's own `Model` bounds; drop the dups.
-        let mut seen = std::collections::HashSet::new();
-        def_wheres.retain(|pred| seen.insert(pred.to_token_stream().to_string()));
+                let mut rewriter = SelfTypeRewriter {
+                    to: syn::parse_quote!(#synth),
+                };
+                for param in &mut fn_params {
+                    rewriter.visit_fn_arg_mut(param);
+                }
+                rewriter.visit_expr_mut(&mut body);
+                for pred in &mut def_wheres {
+                    rewriter.visit_where_predicate_mut(pred);
+                }
+                def_params.push(quote!(#synth));
+                def_wheres.extend(type_lowering.model_where_predicates_for(&synth));
+
+                // Mirror the host's implicit `Self: Trait` bound onto the synthetic
+                // generic so trait associated types (`Self::Item`) and predicates
+                // (`Self::step`) remain resolvable on it.
+                let trait_ident = &item_trait.ident;
+                let (_, ty_generics, _) = item_trait.generics.split_for_impl();
+                def_wheres.push(syn::parse_quote!(#synth: #trait_ident #ty_generics));
+
+                turbofish_args.push(quote!(Self));
+
+                // Rewriting `Self` to the synthetic generic can yield predicates that
+                // duplicate the synthetic generic's own `Model` bounds; drop the dups.
+                let mut seen = std::collections::HashSet::new();
+                def_wheres.retain(|pred| seen.insert(pred.to_token_stream().to_string()));
+            }
+        }
     }
 
     let model_ty_params = type_lowering.lower_params(&fn_params);
@@ -292,18 +318,58 @@ impl VisitMut for SelfValueRewriter {
     }
 }
 
-struct SelfRewriter<'a> {
-    synth: &'a syn::Ident,
+struct SelfTypeRewriter {
+    to: syn::Type,
 }
 
-impl VisitMut for SelfRewriter<'_> {
-    fn visit_path_mut(&mut self, path: &mut syn::Path) {
-        syn::visit_mut::visit_path_mut(self, path);
-        // Rewrite the leading `Self` of any path, covering both the bare type
-        // `Self` and qualified paths such as `Self::Item` / `Self::step`.
-        if path.leading_colon.is_none() && path.segments.first().is_some_and(|s| s.ident == "Self")
-        {
-            path.segments[0].ident = self.synth.clone();
+impl VisitMut for SelfTypeRewriter {
+    fn visit_type_mut(&mut self, ty: &mut syn::Type) {
+        syn::visit_mut::visit_type_mut(self, ty);
+
+        let syn::Type::Path(type_path) = ty else {
+            return;
+        };
+
+        if type_path.qself.is_some() || type_path.path.leading_colon.is_some() {
+            return;
         }
+
+        let mut segments = type_path.path.segments.iter();
+
+        if segments.next().is_none_or(|first| first.ident != "Self") {
+            return;
+        }
+
+        let tail: syn::punctuated::Punctuated<_, syn::Token![::]> = segments.cloned().collect();
+
+        if tail.is_empty() {
+            *ty = self.to.clone();
+        } else {
+            let to = &self.to;
+            *ty = syn::parse_quote!(<#to>::#tail)
+        };
+    }
+
+    fn visit_expr_path_mut(&mut self, expr_path: &mut syn::ExprPath) {
+        syn::visit_mut::visit_expr_path_mut(self, expr_path);
+
+        if expr_path.qself.is_some() || expr_path.path.leading_colon.is_some() {
+            return;
+        }
+
+        let mut segments = expr_path.path.segments.iter();
+
+        if segments.next().is_none_or(|first| first.ident != "Self") {
+            return;
+        }
+
+        let tail: syn::punctuated::Punctuated<_, syn::Token![::]> = segments.cloned().collect();
+
+        if tail.is_empty() {
+            return;
+        }
+
+        let to = &self.to;
+        *expr_path = syn::parse_quote!(<#to>::#tail);
     }
 }

--- a/thrust-macros/src/invariant.rs
+++ b/thrust-macros/src/invariant.rs
@@ -167,6 +167,16 @@ fn expand_invariant(
 
     let mut body = closure.body.clone();
 
+    // An invariant may refer to the receiver value `self`; the lifted formula function is free, so
+    // rewrite `self` to a `__thrust_self` parameter. The analyzer binds it back to the loop-carried receiver.
+    let mut rewriter = SelfValueRewriter {
+        to: format_ident!("__thrust_self"),
+    };
+    for param in &mut fn_params {
+        rewriter.visit_fn_arg_mut(param);
+    }
+    rewriter.visit_expr_mut(&mut body);
+
     // `Self` in a method context: rewrite it to a synthetic generic everywhere
     // it reaches the formula function — parameters, body, and the propagated
     // where-clause predicates — then pass the real `Self` via turbofish (legal
@@ -235,6 +245,51 @@ fn expand_invariant(
 
         thrust_models::__invariant_marker(#name #turbofish)
     }))
+}
+
+struct SelfValueRewriter {
+    to: syn::Ident,
+}
+
+impl VisitMut for SelfValueRewriter {
+    fn visit_pat_ident_mut(&mut self, pat: &mut syn::PatIdent) {
+        if pat.ident == "self" {
+            pat.ident = self.to.clone();
+        }
+        syn::visit_mut::visit_pat_ident_mut(self, pat);
+    }
+
+    fn visit_fn_arg_mut(&mut self, arg: &mut syn::FnArg) {
+        match arg {
+            syn::FnArg::Receiver(receiver) => {
+                let to = &self.to;
+                let ty = &receiver.ty;
+                *arg = syn::parse_quote!(#to: #ty);
+            }
+            syn::FnArg::Typed(_) => { /* handled by visit_pat_ident_mut */ }
+        }
+
+        syn::visit_mut::visit_fn_arg_mut(self, arg);
+    }
+
+    fn visit_expr_path_mut(&mut self, expr_path: &mut syn::ExprPath) {
+        if expr_path.qself.is_some() {
+            syn::visit_mut::visit_expr_path_mut(self, expr_path);
+            return;
+        }
+
+        if expr_path.path.leading_colon.is_some() || expr_path.path.segments.len() != 1 {
+            syn::visit_mut::visit_expr_path_mut(self, expr_path);
+            return;
+        }
+
+        if expr_path.path.segments[0].ident == "self" {
+            expr_path.path.segments[0].ident = self.to.clone();
+            return;
+        }
+
+        syn::visit_mut::visit_expr_path_mut(self, expr_path);
+    }
 }
 
 struct SelfRewriter<'a> {


### PR DESCRIPTION
Enable to use `self` in thrust_macros::invariant! closure parameters. 2e390202def9447eb951092d517ede6f87d4b3cb is essentially unrelated to the main PR subject, but I wanted it for writing test cases, so I'm just going to include it while I'm at it...