### PR TITLE
Enable to refer function parameter at entry in invariant annotations

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -65,6 +65,10 @@ pub fn local_of_function_param(idx: rty::FunctionParamIdx) -> Local {
     Local::from(idx.index() + 1)
 }
 
+pub fn function_param_of_local(local: Local) -> rty::FunctionParamIdx {
+    rty::FunctionParamIdx::from(local.as_usize() - 1)
+}
+
 pub fn resolve_discr(tcx: TyCtxt<'_>, discr: mir_ty::VariantDiscr) -> u32 {
     match discr {
         mir_ty::VariantDiscr::Relative(i) => i,

--- a/src/analyze/annot.rs
+++ b/src/analyze/annot.rs
@@ -153,6 +153,22 @@ pub fn invariant_marker_path() -> [Symbol; 3] {
     ]
 }
 
+pub fn fn_param_wrapper_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("fn_param_wrapper"),
+    ]
+}
+
+pub fn fn_param_at_entry_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("fn_param_at_entry"),
+    ]
+}
+
 pub fn closure_precondition_path() -> [Symbol; 3] {
     [
         Symbol::intern("thrust"),

--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -562,6 +562,14 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
                         let value_term = self.to_term(&args[1]);
                         return FormulaOrTerm::Term(array_term.store(index_term, value_term));
                     }
+                    if Some(def_id) == self.def_ids.fn_param_at_entry() {
+                        assert!(
+                            args.is_empty(),
+                            "FnParam::at_entry does not take any arguments"
+                        );
+                        let t = self.to_term(receiver);
+                        return FormulaOrTerm::Term(t);
+                    }
                 }
                 unimplemented!("unsupported method call in formula: {:?}", method)
             }
@@ -617,6 +625,11 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
                                 vars,
                                 body_formula,
                             ));
+                        }
+                        if Some(def_id) == self.def_ids.fn_param_at_entry() {
+                            assert_eq!(args.len(), 1, "FnParam::at_entry takes exactly 1 argument");
+                            let t = self.to_term(&args[0]);
+                            return FormulaOrTerm::Term(t);
                         }
                         if Some(def_id) == self.def_ids.mut_model_new() {
                             assert_eq!(args.len(), 2, "Mut::new takes exactly 2 arguments");

--- a/src/analyze/did_cache.rs
+++ b/src/analyze/did_cache.rs
@@ -27,6 +27,9 @@ struct DefIds {
     exists: OnceCell<Option<DefId>>,
     invariant_marker: OnceCell<Option<DefId>>,
 
+    fn_param_wrapper: OnceCell<Option<DefId>>,
+    fn_param_at_entry: OnceCell<Option<DefId>>,
+
     closure_precondition: OnceCell<Option<DefId>>,
     closure_postcondition: OnceCell<Option<DefId>>,
 }
@@ -186,6 +189,20 @@ impl<'tcx> DefIdCache<'tcx> {
             .def_ids
             .invariant_marker
             .get_or_init(|| self.annotated_def(&crate::analyze::annot::invariant_marker_path()))
+    }
+
+    pub fn fn_param_wrapper(&self) -> Option<DefId> {
+        *self
+            .def_ids
+            .fn_param_wrapper
+            .get_or_init(|| self.annotated_def(&crate::analyze::annot::fn_param_wrapper_path()))
+    }
+
+    pub fn fn_param_at_entry(&self) -> Option<DefId> {
+        *self
+            .def_ids
+            .fn_param_at_entry
+            .get_or_init(|| self.annotated_def(&crate::analyze::annot::fn_param_at_entry_path()))
     }
 
     pub fn closure_precondition(&self) -> Option<DefId> {

--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -964,6 +964,31 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         found
     }
 
+    fn function_param_local_of_name(&self, name: rustc_span::Symbol) -> Option<Local> {
+        let mut found: Option<Local> = None;
+        for vdi in &self.body.var_debug_info {
+            if vdi.name != name {
+                continue;
+            }
+            let mir::VarDebugInfoContents::Place(place) = vdi.value else {
+                continue;
+            };
+            if !place.projection.is_empty() {
+                continue;
+            }
+            let local = place.local;
+            if local.index() == 0 || local.index() > self.body.arg_count {
+                continue;
+            }
+            match found {
+                None => found = Some(local),
+                Some(prev) if prev == local => {}
+                Some(_) => panic!("multiple function arguments share the name `{name}`"),
+            }
+        }
+        found
+    }
+
     /// Translates a user-provided loop invariant (a formula function over named
     /// live variables) into a precondition refinement over `bty`'s parameters.
     /// Each formula parameter names a live variable at the loop header and is
@@ -979,10 +1004,22 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             .formula_fn_with_args(formula_def_id, generic_args)
             .expect("invariant formula function is not registered");
         let idents = self.tcx.fn_arg_idents(formula_def_id.to_def_id());
+        let sig = self
+            .tcx
+            .fn_sig(formula_def_id.to_def_id())
+            .instantiate(self.tcx, generic_args);
 
         let mut mapping: Vec<rty::FunctionParamIdx> = Vec::with_capacity(idents.len());
-        for ident in idents {
-            let name = ident.expect("invariant parameters must be named").name;
+        for (ident_opt, input_ty) in idents.iter().zip(sig.skip_binder().inputs()) {
+            let name = ident_opt.expect("invariant parameters must be named").name;
+            let input_ty = {
+                let typing_env =
+                    mir_ty::TypingEnv::post_analysis(self.tcx, formula_def_id.to_def_id());
+                self.tcx
+                    .try_normalize_erasing_regions(typing_env, *input_ty)
+                    .unwrap_or(*input_ty)
+            };
+
             // The synthetic `__thrust_self` parameter (emitted when an invariant refers to the receiver
             // `self`) maps to the loop-carried receiver, which appears as `self` in debug info.
             let name = if name.as_str() == "__thrust_self" {
@@ -990,12 +1027,26 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             } else {
                 name
             };
-            let local = self.local_of_name_in_bb(name, bty).unwrap_or_else(|| {
-                self.tcx.dcx().fatal(format!(
-                    "loop invariant refers to `{name}`, which is not a live variable at the loop header"
-                ))
-            });
-            mapping.push(bty.param_of_local(local).unwrap());
+
+            if input_ty
+                .ty_adt_def()
+                .is_some_and(|def| Some(def.did()) == self.ctx.def_ids().fn_param_wrapper())
+            {
+                let local = self.function_param_local_of_name(name).unwrap_or_else(|| {
+                    self.tcx.dcx().fatal(format!(
+                        "loop invariant refers to `{name}` via FnParam, but it is not a function parameter"
+                    ))
+                });
+                let param_idx = crate::analyze::function_param_of_local(local);
+                mapping.push(bty.param_of_outer_fn_param(param_idx).unwrap());
+            } else {
+                let local = self.local_of_name_in_bb(name, bty).unwrap_or_else(|| {
+                    self.tcx.dcx().fatal(format!(
+                        "loop invariant refers to `{name}`, which is not a live variable at the loop header"
+                    ))
+                });
+                mapping.push(bty.param_of_local(local).unwrap());
+            }
         }
 
         formula_fn

--- a/src/refine/basic_block.rs
+++ b/src/refine/basic_block.rs
@@ -122,6 +122,17 @@ impl BasicBlockType {
             .find_map(|(idx, (l, _))| if *l == local { Some(idx) } else { None })
     }
 
+    pub fn param_of_outer_fn_param(
+        &self,
+        idx: rty::FunctionParamIdx,
+    ) -> Option<rty::FunctionParamIdx> {
+        if idx.index() < self.outer_fn_param_count {
+            Some(rty::FunctionParamIdx::from(self.locals.len() + idx.index()))
+        } else {
+            None
+        }
+    }
+
     pub fn to_function_ty(&self) -> rty::FunctionType {
         self.ty.clone()
     }

--- a/std.rs
+++ b/std.rs
@@ -332,6 +332,7 @@ mod thrust_models {
         unimplemented!()
     }
 
+    #[allow(dead_code)]
     #[thrust::def::fn_param_wrapper]
     pub struct FnParam<T>(std::marker::PhantomData<T>);
 

--- a/std.rs
+++ b/std.rs
@@ -331,6 +331,22 @@ mod thrust_models {
     pub fn __invariant_marker<F>(_f: F) {
         unimplemented!()
     }
+
+    #[thrust::def::fn_param_wrapper]
+    pub struct FnParam<T>(std::marker::PhantomData<T>);
+
+    impl<T> Model for FnParam<T> where T: Model {
+        type Ty = FnParam<<T as Model>::Ty>;
+    }
+
+    impl<T> FnParam<T> {
+        #[allow(dead_code)]
+        #[thrust::def::fn_param_at_entry]
+        #[thrust::ignored]
+        pub fn at_entry(self) -> T {
+            unimplemented!()
+        }
+    }
 }
 
 #[thrust::extern_spec_fn]

--- a/tests/ui/fail/loop_invariant_fn_param_at_entry.rs
+++ b/tests/ui/fail/loop_invariant_fn_param_at_entry.rs
@@ -1,0 +1,25 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(result.1 == v.1 + 2)]
+#[thrust_macros::invariant_context]
+fn push_two(v: Vec<i64>) -> Vec<i64> {
+    let mut w = v;
+    let mut i = 0_i64;
+    while i < 2 {
+        thrust_macros::invariant!(
+            |i: i64, w: Vec<i64>, v: thrust_models::FnParam<Vec<i64>>|
+                w.1 == v.at_entry().1 + i && i <= 2
+        );
+        w.push(i);
+        w.push(i);
+        i += 1;
+    }
+    w
+}
+
+fn main() {
+    let v = push_two(Vec::new());
+    assert!(v.len() == 2);
+}

--- a/tests/ui/pass/loop_invariant_fn_param_at_entry.rs
+++ b/tests/ui/pass/loop_invariant_fn_param_at_entry.rs
@@ -1,0 +1,24 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(result.1 == v.1 + 2)]
+#[thrust_macros::invariant_context]
+fn push_two(v: Vec<i64>) -> Vec<i64> {
+    let mut w = v;
+    let mut i = 0_i64;
+    while i < 2 {
+        thrust_macros::invariant!(
+            |i: i64, w: Vec<i64>, v: thrust_models::FnParam<Vec<i64>>|
+                w.1 == v.at_entry().1 + i && i <= 2
+        );
+        w.push(i);
+        i += 1;
+    }
+    w
+}
+
+fn main() {
+    let v = push_two(Vec::new());
+    assert!(v.len() == 2);
+}


### PR DESCRIPTION
Wrapping a parameter type in thrust_models::invariant! using thrust_models::FnParam allows Thrust to recognize that parameter as a snapshot of the function parameter at the start of the function. This is useful when you need to refer to the parameter in the invariant and the parameter does not implement Copy