### PR TITLE
Make closure environments available in annotations

### DIFF
--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -291,8 +291,17 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
         if let mir_ty::TyKind::Ref(_, inner, _) = recv_ty.kind() {
             recv_ty = *inner;
         }
-        let mir_ty::TyKind::Closure(def_id, args) = recv_ty.kind() else {
-            return None;
+        let (def_id, args) = match recv_ty.kind() {
+            mir_ty::TyKind::Closure(def_id, args) => (def_id, args),
+            mir_ty::TyKind::Adt(adt_def, args)
+                if Some(adt_def.did()) == self.def_ids.closure_model() =>
+            {
+                let mir_ty::TyKind::Closure(def_id, args) = args.type_at(0).kind() else {
+                    return None;
+                };
+                (def_id, args)
+            }
+            _ => return None,
         };
         self.analyzer
             .known_function_ty_with_args(*def_id, self.tcx.mk_args(args.as_closure().parent_args()))

--- a/std.rs
+++ b/std.rs
@@ -158,6 +158,13 @@ mod thrust_models {
         #[thrust::def::closure_model]
         pub struct Closure<T: ?Sized>(PhantomData<T>);
 
+        impl<T: ?Sized> PartialEq for Closure<T> {
+            #[thrust::ignored]
+            fn eq(&self, _other: &Self) -> bool {
+                unimplemented!()
+            }
+        }
+
         /// Refers to the precondition of a closure in a specification.
         ///
         /// Prefer the `thrust_macros::pre!(f(x))` surface syntax, which desugars to this; the

--- a/tests/ui/fail/closure_model_preserve.rs
+++ b/tests/ui/fail/closure_model_preserve.rs
@@ -1,0 +1,18 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::ensures(result == f)]
+fn call<F: FnMut() -> i32>(mut f: F) -> F {
+    f();
+    f
+}
+
+fn main() {
+    let mut x = 1;
+    let mut f = call(|| {
+        let y = x;
+        x += 1;
+        y
+    });
+    assert!(f() == 2);
+}

--- a/tests/ui/pass/closure_model_preserve.rs
+++ b/tests/ui/pass/closure_model_preserve.rs
@@ -1,0 +1,16 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::ensures(result == f)]
+fn call<F: FnMut() -> i32>(mut f: F) -> F {
+    f();
+    f
+}
+
+fn main() {
+    let x = 2;
+    let mut f = call(|| {
+        x
+    });
+    assert!(f() == 2);
+}

--- a/thrust-macros/src/formula_fn_type_lowering.rs
+++ b/thrust-macros/src/formula_fn_type_lowering.rs
@@ -37,8 +37,10 @@ impl<'a> FormulaFnTypeLowering<'a> {
 
     /// Maps each function parameter `x: T` to `x: <T as thrust_models::Model>::Ty`.
     ///
-    /// Parameters whose type is a closure/function type parameter `F` stay as `F`, so marker
-    /// functions can recover the instantiated closure definition from the argument type.
+    /// Closure/function type parameters are first rewritten to
+    /// `thrust_models::model::Closure<F>`, including when nested in references such as `&mut F`, so
+    /// specifications can refer to the modeled closure environment while marker functions can still
+    /// recover the instantiated closure definition from `F`.
     pub fn lower_params<'ast, I>(&self, args: I) -> TokenStream2
     where
         I: IntoIterator<Item = &'ast syn::FnArg>,
@@ -53,12 +55,9 @@ impl<'a> FormulaFnTypeLowering<'a> {
                 syn::FnArg::Typed(pt) => {
                     let pat = &pt.pat;
                     let ty = &pt.ty;
-                    if self.is_closure_type_param(ty) {
-                        model_inputs.push(syn::parse_quote!(#pat: #ty));
-                    } else {
-                        model_inputs
-                            .push(syn::parse_quote!(#pat: <#ty as thrust_models::Model>::Ty));
-                    }
+                    let lowered_ty = self.lower_closure_type_params_in_ty(ty);
+                    model_inputs
+                        .push(syn::parse_quote!(#pat: <#lowered_ty as thrust_models::Model>::Ty));
                 }
             }
         }
@@ -69,11 +68,8 @@ impl<'a> FormulaFnTypeLowering<'a> {
         match ret {
             syn::ReturnType::Default => syn::parse_quote!(<() as thrust_models::Model>::Ty),
             syn::ReturnType::Type(_, ty) => {
-                if self.is_closure_type_param(ty) {
-                    *ty.clone()
-                } else {
-                    syn::parse_quote!(<#ty as thrust_models::Model>::Ty)
-                }
+                let lowered_ty = self.lower_closure_type_params_in_ty(ty);
+                syn::parse_quote!(<#lowered_ty as thrust_models::Model>::Ty)
             }
         }
     }
@@ -171,17 +167,34 @@ impl<'a> FormulaFnTypeLowering<'a> {
         predicates
     }
 
-    fn is_closure_type_param(&self, ty: &syn::Type) -> bool {
-        let syn::Type::Path(tp) = ty else {
-            return false;
-        };
-        if tp.qself.is_some() {
-            return false;
+    fn lower_closure_type_params_in_ty(&self, ty: &syn::Type) -> syn::Type {
+        match ty {
+            syn::Type::Path(tp)
+                if tp.qself.is_none()
+                    && tp
+                        .path
+                        .get_ident()
+                        .is_some_and(|ident| self.closure_type_params.contains(ident)) =>
+            {
+                syn::parse_quote!(thrust_models::model::Closure<#ty>)
+            }
+            syn::Type::Reference(tr) => {
+                let mut tr = tr.clone();
+                tr.elem = Box::new(self.lower_closure_type_params_in_ty(&tr.elem));
+                syn::Type::Reference(tr)
+            }
+            syn::Type::Tuple(tt) => {
+                let mut tt = tt.clone();
+                tt.elems = tt
+                    .elems
+                    .iter()
+                    .map(|elem| self.lower_closure_type_params_in_ty(elem))
+                    .collect();
+                syn::Type::Tuple(tt)
+            }
+            // TODO: support more types including ADT
+            _ => ty.clone(),
         }
-        let Some(ident) = tp.path.get_ident() else {
-            return false;
-        };
-        self.closure_type_params.contains(ident)
     }
 }
 


### PR DESCRIPTION
- Closure<T> is now PartialEq, f == g if two closure environments (upvars tuple) are equal
- formula_fn now sees Closure<T> instead of T if T is Fn-bound