### PR TITLE
Add Seq<T> as a model of Vec<T>

### DIFF
--- a/src/analyze/annot.rs
+++ b/src/analyze/annot.rs
@@ -177,6 +177,14 @@ pub fn seq_push_path() -> [Symbol; 3] {
     ]
 }
 
+pub fn seq_concat_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("seq_concat"),
+    ]
+}
+
 pub fn exists_path() -> [Symbol; 3] {
     [
         Symbol::intern("thrust"),

--- a/src/analyze/annot.rs
+++ b/src/analyze/annot.rs
@@ -137,6 +137,46 @@ pub fn array_model_store_path() -> [Symbol; 3] {
     ]
 }
 
+pub fn seq_model_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("seq_model"),
+    ]
+}
+
+pub fn seq_empty_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("seq_empty"),
+    ]
+}
+
+pub fn seq_singleton_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("seq_singleton"),
+    ]
+}
+
+pub fn seq_len_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("seq_len"),
+    ]
+}
+
+pub fn seq_push_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("seq_push"),
+    ]
+}
+
 pub fn exists_path() -> [Symbol; 3] {
     [
         Symbol::intern("thrust"),

--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -430,6 +430,14 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
         FormulaOrTerm::Formula(fn_ty.postcondition_formula(&param_args, result))
     }
 
+    fn node_arg_type_at(&self, hir_id: HirId, idx: usize) -> rty::Type<rty::Closed> {
+        let generic_args = self.typeck.node_args(hir_id);
+        let generic_args =
+            mir_ty::EarlyBinder::bind(generic_args).instantiate(self.tcx, self.generic_args);
+        let elem_ty = generic_args.type_at(idx);
+        self.type_builder.build(elem_ty)
+    }
+
     fn variant_ctor_term(
         &self,
         ctor_did: rustc_span::def_id::DefId,
@@ -623,9 +631,18 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
                 FormulaOrTerm::Term(term.tuple_proj(index))
             }
             ExprKind::Index(array, index, _) => {
+                let array_ty = self.expr_ty(array);
                 let array_term = self.to_term(array);
                 let index_term = self.to_term(index);
-                FormulaOrTerm::Term(array_term.select(index_term))
+                let is_seq = array_ty
+                    .ty_adt_def()
+                    .is_some_and(|adt| Some(adt.did()) == self.def_ids.seq_model());
+                let array_inner = if is_seq {
+                    array_term.tuple_proj(0)
+                } else {
+                    array_term
+                };
+                FormulaOrTerm::Term(array_inner.select(index_term))
             }
             ExprKind::MethodCall(method, receiver, args, _) => {
                 if let Some(def_id) = self.typeck.type_dependent_def_id(hir.hir_id) {
@@ -643,6 +660,21 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
                         );
                         let t = self.to_term(receiver);
                         return FormulaOrTerm::Term(t);
+                    }
+                    if Some(def_id) == self.def_ids.seq_len() {
+                        assert!(args.is_empty(), "Seq::len does not take any arguments");
+                        let t = self.to_term(receiver);
+                        return FormulaOrTerm::Term(t.tuple_proj(1));
+                    }
+                    if Some(def_id) == self.def_ids.seq_push() {
+                        assert_eq!(args.len(), 1, "Seq::push takes exactly 1 argument");
+                        let t = self.to_term(receiver);
+                        let v = self.to_term(&args[0]);
+                        let arr = t.clone().tuple_proj(0);
+                        let len = t.tuple_proj(1);
+                        let new_arr = arr.store(len.clone(), v);
+                        let new_len = len.add(chc::Term::int(1));
+                        return FormulaOrTerm::Term(chc::Term::tuple(vec![new_arr, new_len]));
                     }
                 }
                 unimplemented!("unsupported method call in formula: {:?}", method)
@@ -718,6 +750,25 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
                             assert_eq!(args.len(), 1, "Box::new takes exactly 1 argument");
                             let t = self.to_term(&args[0]);
                             return FormulaOrTerm::Term(chc::Term::box_(t));
+                        }
+                        if Some(def_id) == self.def_ids.seq_empty() {
+                            assert!(args.is_empty(), "Seq::empty does not take any arguments");
+                            let elem_sort = self.node_arg_type_at(func_expr.hir_id, 0).to_sort();
+                            return FormulaOrTerm::Term(chc::Term::tuple(vec![
+                                chc::Term::array_empty(chc::Sort::int(), elem_sort),
+                                chc::Term::int(0),
+                            ]));
+                        }
+                        if Some(def_id) == self.def_ids.seq_singleton() {
+                            assert_eq!(args.len(), 1, "Seq::singleton takes exactly 1 argument");
+                            let v = self.to_term(&args[0]);
+                            let elem_sort = self.node_arg_type_at(func_expr.hir_id, 0).to_sort();
+                            let new_arr = chc::Term::array_empty(chc::Sort::int(), elem_sort)
+                                .store(chc::Term::int(0), v);
+                            return FormulaOrTerm::Term(chc::Term::tuple(vec![
+                                new_arr,
+                                chc::Term::int(1),
+                            ]));
                         }
                         if let rustc_hir::def::DefKind::Ctor(ctor_of, _) = def_kind {
                             let terms = args.iter().map(|e| self.to_term(e)).collect();

--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -438,6 +438,17 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
         self.type_builder.build(elem_ty)
     }
 
+    fn adt_arg_type_at(
+        &self,
+        expr: &'tcx rustc_hir::Expr<'tcx>,
+        idx: usize,
+    ) -> rty::Type<rty::Closed> {
+        let mir_ty::TyKind::Adt(_, args) = self.expr_ty(expr).kind() else {
+            panic!("expected ADT");
+        };
+        self.type_builder.build(args.type_at(idx))
+    }
+
     fn variant_ctor_term(
         &self,
         ctor_did: rustc_span::def_id::DefId,
@@ -674,6 +685,25 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
                         let len = t.tuple_proj(1);
                         let new_arr = arr.store(len.clone(), v);
                         let new_len = len.add(chc::Term::int(1));
+                        return FormulaOrTerm::Term(chc::Term::tuple(vec![new_arr, new_len]));
+                    }
+                    if Some(def_id) == self.def_ids.seq_concat() {
+                        assert_eq!(args.len(), 1, "Seq::concat takes exactly 1 argument");
+                        let elem_sort = self.adt_arg_type_at(receiver, 0).to_sort();
+                        let t = self.to_term(receiver);
+                        let other = self.to_term(&args[0]);
+                        let a_arr = t.clone().tuple_proj(0);
+                        let a_len = t.tuple_proj(1);
+                        let b_arr = other.clone().tuple_proj(0);
+                        let b_len = other.tuple_proj(1);
+                        let new_arr = chc::Term::array_concat(
+                            elem_sort,
+                            a_arr,
+                            a_len.clone(),
+                            b_arr,
+                            b_len.clone(),
+                        );
+                        let new_len = a_len.add(b_len);
                         return FormulaOrTerm::Term(chc::Term::tuple(vec![new_arr, new_len]));
                     }
                 }

--- a/src/analyze/did_cache.rs
+++ b/src/analyze/did_cache.rs
@@ -24,6 +24,12 @@ struct DefIds {
     box_model_new: OnceCell<Option<DefId>>,
     array_model_store: OnceCell<Option<DefId>>,
 
+    seq_model: OnceCell<Option<DefId>>,
+    seq_empty: OnceCell<Option<DefId>>,
+    seq_singleton: OnceCell<Option<DefId>>,
+    seq_len: OnceCell<Option<DefId>>,
+    seq_push: OnceCell<Option<DefId>>,
+
     exists: OnceCell<Option<DefId>>,
     forall: OnceCell<Option<DefId>>,
     implies: OnceCell<Option<DefId>>,
@@ -177,6 +183,41 @@ impl<'tcx> DefIdCache<'tcx> {
             .def_ids
             .array_model_store
             .get_or_init(|| self.annotated_def(&crate::analyze::annot::array_model_store_path()))
+    }
+
+    pub fn seq_model(&self) -> Option<DefId> {
+        *self
+            .def_ids
+            .seq_model
+            .get_or_init(|| self.annotated_def(&crate::analyze::annot::seq_model_path()))
+    }
+
+    pub fn seq_empty(&self) -> Option<DefId> {
+        *self
+            .def_ids
+            .seq_empty
+            .get_or_init(|| self.annotated_def(&crate::analyze::annot::seq_empty_path()))
+    }
+
+    pub fn seq_singleton(&self) -> Option<DefId> {
+        *self
+            .def_ids
+            .seq_singleton
+            .get_or_init(|| self.annotated_def(&crate::analyze::annot::seq_singleton_path()))
+    }
+
+    pub fn seq_len(&self) -> Option<DefId> {
+        *self
+            .def_ids
+            .seq_len
+            .get_or_init(|| self.annotated_def(&crate::analyze::annot::seq_len_path()))
+    }
+
+    pub fn seq_push(&self) -> Option<DefId> {
+        *self
+            .def_ids
+            .seq_push
+            .get_or_init(|| self.annotated_def(&crate::analyze::annot::seq_push_path()))
     }
 
     pub fn exists(&self) -> Option<DefId> {

--- a/src/analyze/did_cache.rs
+++ b/src/analyze/did_cache.rs
@@ -29,6 +29,7 @@ struct DefIds {
     seq_singleton: OnceCell<Option<DefId>>,
     seq_len: OnceCell<Option<DefId>>,
     seq_push: OnceCell<Option<DefId>>,
+    seq_concat: OnceCell<Option<DefId>>,
 
     exists: OnceCell<Option<DefId>>,
     forall: OnceCell<Option<DefId>>,
@@ -218,6 +219,13 @@ impl<'tcx> DefIdCache<'tcx> {
             .def_ids
             .seq_push
             .get_or_init(|| self.annotated_def(&crate::analyze::annot::seq_push_path()))
+    }
+
+    pub fn seq_concat(&self) -> Option<DefId> {
+        *self
+            .def_ids
+            .seq_concat
+            .get_or_init(|| self.annotated_def(&crate::analyze::annot::seq_concat_path()))
     }
 
     pub fn exists(&self) -> Option<DefId> {

--- a/src/annot.rs
+++ b/src/annot.rs
@@ -91,7 +91,7 @@ pub struct AnnotPathSegment {
 
 /// A trait for resolving variables in annotations to their logical representation and their sorts.
 pub trait Resolver {
-    type Output;
+    type Output: Clone;
     fn resolve(&self, ident: Ident) -> Option<(Self::Output, chc::Sort)>;
 }
 
@@ -1222,7 +1222,7 @@ struct RefinementResolver<'a, T> {
     self_: Option<(Ident, chc::Sort)>,
 }
 
-impl<'a, T> Resolver for RefinementResolver<'a, T> {
+impl<'a, T: Clone> Resolver for RefinementResolver<'a, T> {
     type Output = rty::RefinedTypeVar<T>;
     fn resolve(&self, ident: Ident) -> Option<(Self::Output, chc::Sort)> {
         if let Some((self_ident, sort)) = &self.self_ {
@@ -1256,7 +1256,7 @@ pub struct MappedResolver<'a, T, F> {
     map: F,
 }
 
-impl<'a, T, F, U> Resolver for MappedResolver<'a, T, F>
+impl<'a, T: Clone, F, U: Clone> Resolver for MappedResolver<'a, T, F>
 where
     F: Fn(T) -> U,
 {
@@ -1290,7 +1290,7 @@ impl<'a, T> Default for StackedResolver<'a, T> {
     }
 }
 
-impl<'a, T> Resolver for StackedResolver<'a, T> {
+impl<'a, T: Clone> Resolver for StackedResolver<'a, T> {
     type Output = T;
     fn resolve(&self, ident: Ident) -> Option<(Self::Output, chc::Sort)> {
         for resolver in &self.resolvers {

--- a/src/chc.rs
+++ b/src/chc.rs
@@ -414,6 +414,7 @@ impl Function {
                 };
                 *elem
             }
+            Self::ITE => args.into_iter().nth(1).unwrap(),
             _ => unimplemented!(),
         }
     }
@@ -432,6 +433,7 @@ impl Function {
     pub const NEG: Function = Function::new("-");
     pub const STORE: Function = Function::new("store");
     pub const SELECT: Function = Function::new("select");
+    pub const ITE: Function = Function::new("ite");
 }
 
 #[derive(Debug, Clone)]
@@ -859,8 +861,57 @@ impl<V> Term<V> {
         Term::App(Function::NEG, vec![self])
     }
 
-    pub fn select(self, index: Self) -> Self {
+    pub fn select(self, index: Self) -> Self
+    where
+        V: Clone,
+    {
+        // Peephole 1: when both indices are concrete integer literals, reduce `select(store(a, i,
+        // v), j)` to `v` (`i == j`) or `select(a, j)` (`i != j`). Same motivation as the
+        // `tuple_proj` simplifier: keep datatype/array constructors from leaking into Spacer
+        // clauses where it can't reduce them. Non-literal indices are deferred to the solver via
+        // the general select-of-store axiom.
+        if let (Term::App(Function::STORE, _), Term::Int(j)) = (&self, &index) {
+            let Term::App(_, mut args) = self else {
+                unreachable!()
+            };
+            assert_eq!(args.len(), 3, "STORE takes 3 args");
+            let stored_value = args.pop().unwrap();
+            let stored_index = args.pop().unwrap();
+            let base = args.pop().unwrap();
+            if let Term::Int(i) = &stored_index {
+                return if i == j {
+                    stored_value
+                } else {
+                    base.select(index)
+                };
+            }
+            return Term::App(
+                Function::SELECT,
+                vec![
+                    Term::App(Function::STORE, vec![base, stored_index, stored_value]),
+                    index,
+                ],
+            );
+        }
+        // Peephole 2: inline one step of the `concat_int_array` recursive definitions to reduce
+        // indexed access to terms over the underlying sequences. The SMT-defined functions are
+        // still emitted (so the rewrites use exactly their unfolded form), but pcsat can prove
+        // indexed properties against the inlined ITE for *any* recursion bound, where unfolding
+        // through `define-fun-rec` would require an inductive invariant pcsat can't find.
+        //
+        // `select(concat_int_array(sa, sn, ta, tn), i)
+        //   ↦ ite(i < sn, select(sa, i), select(ta, i - sn))`
+        if let Term::ArrayConcat(_, t) = self {
+            let cond = index.clone().lt(t.len1.clone());
+            let then_ = t.array1.select(index.clone());
+            let else_ = t.array2.select(index.sub(t.len1));
+            return Term::ite(cond, then_, else_);
+        }
         Term::App(Function::SELECT, vec![self, index])
+    }
+
+    pub fn ite(cond: Self, then_: Self, else_: Self) -> Self {
+        Term::App(Function::ITE, vec![cond, then_, else_])
     }
 
     pub fn store(self, index: Self, elem: Self) -> Self {
@@ -872,6 +923,11 @@ impl<V> Term<V> {
     }
 
     pub fn tuple_proj(self, i: usize) -> Self {
+        // Spacer doesn't unfold tuple projections of literal constructors.
+        if let Term::Tuple(mut ts) = self {
+            assert!(i < ts.len(), "tuple_proj index out of bounds");
+            return ts.swap_remove(i);
+        }
         Term::TupleProj(Box::new(self), i)
     }
 

--- a/src/chc.rs
+++ b/src/chc.rs
@@ -448,6 +448,7 @@ pub enum Term<V = TermVarIdx> {
     MutCurrent(Box<Term<V>>),
     MutFinal(Box<Term<V>>),
     App(Function, Vec<Term<V>>),
+    ArrayEmpty(Sort, Sort),
     Tuple(Vec<Term<V>>),
     TupleProj(Box<Term<V>>, usize),
     DatatypeCtor(DatatypeSort, DatatypeSymbol, Vec<Term<V>>),
@@ -499,6 +500,7 @@ where
                     f.append(allocator.line()).append(inner.nest(2)).group()
                 }
             }
+            Term::ArrayEmpty(_, _) => allocator.text("[]"),
             Term::Tuple(ts) => {
                 let separator = allocator.text(",").append(allocator.line());
                 if ts.len() == 1 {
@@ -562,6 +564,7 @@ impl<V> Term<V> {
             Term::App(fun, args) => {
                 Term::App(fun, args.into_iter().map(|t| t.subst_var(&mut f)).collect())
             }
+            Term::ArrayEmpty(s1, s2) => Term::ArrayEmpty(s1, s2),
             Term::Tuple(ts) => Term::Tuple(ts.into_iter().map(|t| t.subst_var(&mut f)).collect()),
             Term::TupleProj(t, i) => Term::TupleProj(Box::new(t.subst_var(f)), i),
             Term::DatatypeCtor(sort, c_sym, args) => Term::DatatypeCtor(
@@ -608,6 +611,7 @@ impl<V> Term<V> {
                 let mut var_sort: Box<dyn FnMut(&V) -> Sort> = Box::new(var_sort);
                 fun.sort(args.iter().map(|t| t.sort(&mut var_sort)))
             }
+            Term::ArrayEmpty(index, elem) => Sort::array(index.clone(), elem.clone()),
             Term::Tuple(ts) => {
                 // TODO: remove this
                 let mut var_sort: Box<dyn FnMut(&V) -> Sort> = Box::new(var_sort);
@@ -627,6 +631,7 @@ impl<V> Term<V> {
             | Term::Bool(_)
             | Term::Int(_)
             | Term::String(_)
+            | Term::ArrayEmpty { .. }
             | Term::FormulaQuantifiedVar { .. } => Box::new(std::iter::empty()),
             Term::Box(t) => t.fv_impl(),
             Term::Mut(t1, t2) => Box::new(t1.fv_impl().chain(t2.fv_impl())),
@@ -665,12 +670,39 @@ impl<V> Term<V> {
         Term::String(s)
     }
 
+    /// Some canonical value of the given sort. The exact value is unspecified;
+    /// callers must only use it where any well-typed value would do (e.g. the
+    /// element value of an [`Term::ArrayEmpty`]).
+    pub fn default_for(sort: &Sort) -> Self {
+        match sort {
+            Sort::Null => Term::Null,
+            Sort::Int => Term::Int(0),
+            Sort::Bool => Term::Bool(false),
+            Sort::String => Term::String(String::new()),
+            Sort::Box(s) => Term::Box(Box::new(Self::default_for(s))),
+            Sort::Mut(s) => Term::Mut(
+                Box::new(Self::default_for(s)),
+                Box::new(Self::default_for(s)),
+            ),
+            Sort::Tuple(ts) => Term::Tuple(ts.iter().map(Self::default_for).collect()),
+            Sort::Array(i, e) => Term::ArrayEmpty((**i).clone(), (**e).clone()),
+            // TODO: defaults for Datatype and Param.
+            Sort::Datatype(_) | Sort::Param(_) => {
+                unimplemented!("no default value for sort {sort:?}")
+            }
+        }
+    }
+
     pub fn box_(t: Term<V>) -> Self {
         Term::Box(Box::new(t))
     }
 
     pub fn mut_(t1: Term<V>, t2: Term<V>) -> Self {
         Term::Mut(Box::new(t1), Box::new(t2))
+    }
+
+    pub fn array_empty(index: Sort, elem: Sort) -> Self {
+        Term::ArrayEmpty(index, elem)
     }
 
     pub fn boxed(self) -> Self {

--- a/src/chc.rs
+++ b/src/chc.rs
@@ -434,6 +434,66 @@ impl Function {
     pub const SELECT: Function = Function::new("select");
 }
 
+#[derive(Debug, Clone)]
+pub struct ArrayConcatTerm<V = TermVarIdx> {
+    pub array1: Term<V>,
+    pub len1: Term<V>,
+    pub array2: Term<V>,
+    pub len2: Term<V>,
+}
+
+impl<'a, D, V> Pretty<'a, D, termcolor::ColorSpec> for &ArrayConcatTerm<V>
+where
+    V: Var,
+    D: pretty::DocAllocator<'a, termcolor::ColorSpec>,
+    D::Doc: Clone,
+{
+    fn pretty(self, allocator: &'a D) -> pretty::DocBuilder<'a, D, termcolor::ColorSpec> {
+        allocator
+            .text("concat")
+            .append(allocator.line())
+            .append(self.array1.pretty_atom(allocator))
+            .append(allocator.text(","))
+            .append(allocator.line())
+            .append(self.len1.pretty_atom(allocator))
+            .append(allocator.text(","))
+            .append(allocator.line())
+            .append(self.array2.pretty_atom(allocator))
+            .append(allocator.text(","))
+            .append(allocator.line())
+            .append(self.len2.pretty_atom(allocator))
+            .parens()
+    }
+}
+
+impl<V> ArrayConcatTerm<V> {
+    pub fn iter_args(&self) -> impl Iterator<Item = &Term<V>> {
+        std::iter::once(&self.array1)
+            .chain(std::iter::once(&self.len1))
+            .chain(std::iter::once(&self.array2))
+            .chain(std::iter::once(&self.len2))
+    }
+
+    pub fn iter_args_mut(&mut self) -> impl Iterator<Item = &mut Term<V>> {
+        std::iter::once(&mut self.array1)
+            .chain(std::iter::once(&mut self.len1))
+            .chain(std::iter::once(&mut self.array2))
+            .chain(std::iter::once(&mut self.len2))
+    }
+
+    pub fn subst_var<F, W>(self, mut f: F) -> ArrayConcatTerm<W>
+    where
+        F: FnMut(V) -> Term<W>,
+    {
+        ArrayConcatTerm {
+            array1: self.array1.subst_var(&mut f),
+            len1: self.len1.subst_var(&mut f),
+            array2: self.array2.subst_var(&mut f),
+            len2: self.len2.subst_var(f),
+        }
+    }
+}
+
 /// A logical term.
 #[derive(Debug, Clone)]
 pub enum Term<V = TermVarIdx> {
@@ -449,6 +509,7 @@ pub enum Term<V = TermVarIdx> {
     MutFinal(Box<Term<V>>),
     App(Function, Vec<Term<V>>),
     ArrayEmpty(Sort, Sort),
+    ArrayConcat(Sort, Box<ArrayConcatTerm<V>>),
     Tuple(Vec<Term<V>>),
     TupleProj(Box<Term<V>>, usize),
     DatatypeCtor(DatatypeSort, DatatypeSymbol, Vec<Term<V>>),
@@ -501,6 +562,7 @@ where
                 }
             }
             Term::ArrayEmpty(_, _) => allocator.text("[]"),
+            Term::ArrayConcat(_, t) => t.pretty(allocator),
             Term::Tuple(ts) => {
                 let separator = allocator.text(",").append(allocator.line());
                 if ts.len() == 1 {
@@ -565,6 +627,7 @@ impl<V> Term<V> {
                 Term::App(fun, args.into_iter().map(|t| t.subst_var(&mut f)).collect())
             }
             Term::ArrayEmpty(s1, s2) => Term::ArrayEmpty(s1, s2),
+            Term::ArrayConcat(s, t) => Term::ArrayConcat(s, Box::new(t.subst_var(f))),
             Term::Tuple(ts) => Term::Tuple(ts.into_iter().map(|t| t.subst_var(&mut f)).collect()),
             Term::TupleProj(t, i) => Term::TupleProj(Box::new(t.subst_var(f)), i),
             Term::DatatypeCtor(sort, c_sym, args) => Term::DatatypeCtor(
@@ -612,6 +675,7 @@ impl<V> Term<V> {
                 fun.sort(args.iter().map(|t| t.sort(&mut var_sort)))
             }
             Term::ArrayEmpty(index, elem) => Sort::array(index.clone(), elem.clone()),
+            Term::ArrayConcat(elem, _) => Sort::array(Sort::int(), elem.clone()),
             Term::Tuple(ts) => {
                 // TODO: remove this
                 let mut var_sort: Box<dyn FnMut(&V) -> Sort> = Box::new(var_sort);
@@ -639,6 +703,7 @@ impl<V> Term<V> {
             Term::MutCurrent(t) => t.fv_impl(),
             Term::MutFinal(t) => t.fv_impl(),
             Term::App(_, args) => Box::new(args.iter().flat_map(|t| t.fv_impl())),
+            Term::ArrayConcat(_, t) => Box::new(t.iter_args().flat_map(|t| t.fv_impl())),
             Term::Tuple(ts) => Box::new(ts.iter().flat_map(|t| t.fv_impl())),
             Term::TupleProj(t, _) => t.fv_impl(),
             Term::DatatypeCtor(_, _, args) => Box::new(args.iter().flat_map(|t| t.fv_impl())),
@@ -703,6 +768,24 @@ impl<V> Term<V> {
 
     pub fn array_empty(index: Sort, elem: Sort) -> Self {
         Term::ArrayEmpty(index, elem)
+    }
+
+    pub fn array_concat(
+        elem_sort: Sort,
+        array1: Term<V>,
+        len1: Term<V>,
+        array2: Term<V>,
+        len2: Term<V>,
+    ) -> Self {
+        Term::ArrayConcat(
+            elem_sort,
+            Box::new(ArrayConcatTerm {
+                array1,
+                len1,
+                array2,
+                len2,
+            }),
+        )
     }
 
     pub fn boxed(self) -> Self {

--- a/src/chc/format_context.rs
+++ b/src/chc/format_context.rs
@@ -21,6 +21,7 @@ use crate::chc::{self, hoice::HoiceDatatypeRenamer};
 pub struct FormatContext {
     renamer: HoiceDatatypeRenamer,
     datatypes: Vec<chc::Datatype>,
+    int_array_elem_sorts: BTreeSet<chc::Sort>,
 }
 
 // FIXME: this is obviously ineffective and should be replaced
@@ -46,6 +47,11 @@ fn term_sorts(clause: &chc::Clause, t: &chc::Term, sorts: &mut BTreeSet<chc::Sor
             }
         }
         chc::Term::ArrayEmpty(_, _) => {}
+        chc::Term::ArrayConcat(_, t) => {
+            for arg in t.iter_args() {
+                term_sorts(clause, arg, sorts);
+            }
+        }
         chc::Term::Tuple(ts) => {
             for t in ts {
                 term_sorts(clause, t, sorts);
@@ -270,6 +276,13 @@ impl FormatContext {
                 datatypes.push(mono_datatype);
             }
         }
+        let int_array_elem_sorts: BTreeSet<_> = sorts
+            .iter()
+            .filter_map(|s| match s {
+                chc::Sort::Array(index, elem) if **index == chc::Sort::int() => Some(*elem.clone()),
+                _ => None,
+            })
+            .collect();
         let datatypes: Vec<_> = sorts
             .into_iter()
             .flat_map(builtin_sort_datatype)
@@ -277,11 +290,19 @@ impl FormatContext {
             .filter(|d| d.params == 0)
             .collect();
         let renamer = HoiceDatatypeRenamer::new(&datatypes);
-        FormatContext { renamer, datatypes }
+        FormatContext {
+            renamer,
+            datatypes,
+            int_array_elem_sorts,
+        }
     }
 
     pub fn datatypes(&self) -> &[chc::Datatype] {
         &self.datatypes
+    }
+
+    pub fn int_array_elem_sorts(&self) -> &BTreeSet<chc::Sort> {
+        &self.int_array_elem_sorts
     }
 
     pub fn box_ctor(&self, sort: &chc::Sort) -> impl std::fmt::Display {
@@ -346,6 +367,11 @@ impl FormatContext {
 
     pub fn matcher_pred_def(&self, sym: &chc::DatatypeSymbol) -> impl std::fmt::Display {
         format!("matcher_pred<{}>", self.fmt_datatype_symbol(sym))
+    }
+
+    pub fn concat_int_array(&self, elem: &chc::Sort) -> impl std::fmt::Display {
+        let elem = SortSymbol::new(elem);
+        format!("concat_int_array<{}>", elem)
     }
 
     fn fmt_sort_impl(&self, sort: &chc::Sort) -> Box<dyn std::fmt::Display> {

--- a/src/chc/format_context.rs
+++ b/src/chc/format_context.rs
@@ -45,6 +45,7 @@ fn term_sorts(clause: &chc::Clause, t: &chc::Term, sorts: &mut BTreeSet<chc::Sor
                 term_sorts(clause, arg, sorts);
             }
         }
+        chc::Term::ArrayEmpty(_, _) => {}
         chc::Term::Tuple(ts) => {
             for t in ts {
                 term_sorts(clause, t, sorts);

--- a/src/chc/smtlib2.rs
+++ b/src/chc/smtlib2.rs
@@ -159,6 +159,16 @@ impl<'ctx, 'a> std::fmt::Display for Term<'ctx, 'a> {
                     List::open(args.iter().map(|t| Term::new(self.ctx, self.clause, t)))
                 )
             }
+            chc::Term::ArrayEmpty(index, elem) => {
+                let index_sort = self.ctx.fmt_sort(index);
+                let elem_sort = self.ctx.fmt_sort(elem);
+                let default = chc::Term::default_for(elem);
+                write!(
+                    f,
+                    "((as const (Array {index_sort} {elem_sort})) {})",
+                    Term::new(self.ctx, self.clause, &default)
+                )
+            }
             chc::Term::Tuple(ts) => {
                 let ss: Vec<_> = ts.iter().map(|t| self.clause.term_sort(t)).collect();
                 if ss.is_empty() {

--- a/src/chc/smtlib2.rs
+++ b/src/chc/smtlib2.rs
@@ -169,6 +169,15 @@ impl<'ctx, 'a> std::fmt::Display for Term<'ctx, 'a> {
                     Term::new(self.ctx, self.clause, &default)
                 )
             }
+            chc::Term::ArrayConcat(elem, t) => {
+                let name = self.ctx.concat_int_array(elem);
+                write!(
+                    f,
+                    "({} {})",
+                    name,
+                    List::open(t.iter_args().map(|t| Term::new(self.ctx, self.clause, t)))
+                )
+            }
             chc::Term::Tuple(ts) => {
                 let ss: Vec<_> = ts.iter().map(|t| self.clause.term_sort(t)).collect();
                 if ss.is_empty() {
@@ -627,6 +636,21 @@ impl<'a> std::fmt::Display for System<'a> {
         for datatype in self.ctx.datatypes() {
             writeln!(f, "{}", DatatypeDiscrFun::new(&self.ctx, datatype))?;
             writeln!(f, "{}", MatcherPredFun::new(&self.ctx, datatype))?;
+        }
+
+        for elem in self.ctx.int_array_elem_sorts() {
+            let name = self.ctx.concat_int_array(elem);
+            let elem_ty = self.ctx.fmt_sort(elem);
+            writeln!(
+                f,
+                "(define-fun-rec {name} \
+                  ((sa (Array Int {elem_ty})) (sn Int) (ta (Array Int {elem_ty})) (tn Int)) \
+                  (Array Int {elem_ty}) \
+                  (ite (<= tn 0) sa \
+                       (store ({name} sa sn ta (- tn 1)) \
+                              (+ sn (- tn 1)) \
+                              (select ta (- tn 1)))))\n",
+            )?;
         }
 
         // insert command from #![thrust::raw_command()] here

--- a/src/chc/unbox.rs
+++ b/src/chc/unbox.rs
@@ -2,6 +2,25 @@
 
 use super::*;
 
+fn unbox_array_concat_term(t: ArrayConcatTerm) -> ArrayConcatTerm {
+    let ArrayConcatTerm {
+        array1,
+        len1,
+        array2,
+        len2,
+    } = t;
+    let array1 = unbox_term(array1);
+    let len1 = unbox_term(len1);
+    let array2 = unbox_term(array2);
+    let len2 = unbox_term(len2);
+    ArrayConcatTerm {
+        array1,
+        len1,
+        array2,
+        len2,
+    }
+}
+
 fn unbox_term(term: Term) -> Term {
     match term {
         Term::Var(_) | Term::Bool(_) | Term::Int(_) | Term::String(_) | Term::Null => term,
@@ -12,6 +31,9 @@ fn unbox_term(term: Term) -> Term {
         Term::MutFinal(t) => Term::MutFinal(Box::new(unbox_term(*t))),
         Term::App(fun, args) => Term::App(fun, args.into_iter().map(unbox_term).collect()),
         Term::ArrayEmpty(s1, s2) => Term::ArrayEmpty(unbox_sort(s1), unbox_sort(s2)),
+        Term::ArrayConcat(s, t) => {
+            Term::ArrayConcat(unbox_sort(s), Box::new(unbox_array_concat_term(*t)))
+        }
         Term::Tuple(ts) => Term::Tuple(ts.into_iter().map(unbox_term).collect()),
         Term::TupleProj(t, i) => Term::TupleProj(Box::new(unbox_term(*t)), i),
         Term::DatatypeCtor(s1, s2, args) => Term::DatatypeCtor(

--- a/src/chc/unbox.rs
+++ b/src/chc/unbox.rs
@@ -11,6 +11,7 @@ fn unbox_term(term: Term) -> Term {
         Term::MutCurrent(t) => Term::MutCurrent(Box::new(unbox_term(*t))),
         Term::MutFinal(t) => Term::MutFinal(Box::new(unbox_term(*t))),
         Term::App(fun, args) => Term::App(fun, args.into_iter().map(unbox_term).collect()),
+        Term::ArrayEmpty(s1, s2) => Term::ArrayEmpty(unbox_sort(s1), unbox_sort(s2)),
         Term::Tuple(ts) => Term::Tuple(ts.into_iter().map(unbox_term).collect()),
         Term::TupleProj(t, i) => Term::TupleProj(Box::new(unbox_term(*t)), i),
         Term::DatatypeCtor(s1, s2, args) => Term::DatatypeCtor(

--- a/src/rty.rs
+++ b/src/rty.rs
@@ -1978,6 +1978,12 @@ fn subst_ty_params_in_term<T, V>(term: &mut chc::Term<V>, subst: &TypeParamSubst
             subst_ty_params_in_sort(s1, subst);
             subst_ty_params_in_sort(s2, subst);
         }
+        chc::Term::ArrayConcat(sort, t) => {
+            subst_ty_params_in_sort(sort, subst);
+            for arg in t.iter_args_mut() {
+                subst_ty_params_in_term(arg, subst);
+            }
+        }
         chc::Term::DatatypeCtor(s, _, args) => {
             for arg in s.args_mut() {
                 subst_ty_params_in_sort(arg, subst);

--- a/src/rty.rs
+++ b/src/rty.rs
@@ -1974,6 +1974,10 @@ fn subst_ty_params_in_term<T, V>(term: &mut chc::Term<V>, subst: &TypeParamSubst
                 subst_ty_params_in_term(arg, subst);
             }
         }
+        chc::Term::ArrayEmpty(s1, s2) => {
+            subst_ty_params_in_sort(s1, subst);
+            subst_ty_params_in_sort(s2, subst);
+        }
         chc::Term::DatatypeCtor(s, _, args) => {
             for arg in s.args_mut() {
                 subst_ty_params_in_sort(arg, subst);

--- a/std.rs
+++ b/std.rs
@@ -187,15 +187,6 @@ mod thrust_models {
             unimplemented!()
         }
 
-        pub struct Vec<T: ?Sized>(pub Array<Int, T>, pub Int);
-
-        impl<T, U> PartialEq<U> for Vec<T> where U: super::Model<Ty = Self> {
-            #[thrust::ignored]
-            fn eq(&self, _other: &U) -> bool {
-                unimplemented!()
-            }
-        }
-
         #[thrust::def::seq_model]
         pub struct Seq<T: ?Sized>(pub Array<Int, T>, pub Int);
 
@@ -253,8 +244,8 @@ mod thrust_models {
         }
     }
 
-    impl<T> Model for model::Seq<T> where T: Model {
-        type Ty = model::Seq<<T as Model>::Ty>;
+    impl<T: ?Sized> Model for model::Seq<T> {
+        type Ty = model::Seq<T>;
     }
 
     impl Model for model::Int {
@@ -370,11 +361,7 @@ mod thrust_models {
     }
 
     impl<T> Model for Vec<T> where T: Model {
-        type Ty = model::Vec<<T as Model>::Ty>;
-    }
-
-    impl<T: ?Sized> Model for model::Vec<T> {
-        type Ty = model::Vec<T>;
+        type Ty = model::Seq<<T as Model>::Ty>;
     }
 
     impl<T> Model for Option<T> where T: Model {
@@ -727,7 +714,7 @@ fn _extern_spec_vec_new<T>() -> Vec<T> where T: thrust_models::Model, T::Ty: Par
 
 #[thrust::extern_spec_fn]
 #[thrust_macros::requires(true)]
-#[thrust_macros::ensures(!vec == thrust_models::model::Vec((*vec).0.store((*vec).1, elem), (*vec).1 + 1))]
+#[thrust_macros::ensures(!vec == thrust_models::model::Seq((*vec).0.store((*vec).1, elem), (*vec).1 + 1))]
 fn _extern_spec_vec_push<T>(vec: &mut Vec<T>, elem: T)
     where T: thrust_models::Model, T::Ty: PartialEq
 {
@@ -753,7 +740,7 @@ fn _extern_spec_vec_index<T>(vec: &Vec<T>, index: usize) -> &T where T: thrust_m
 #[thrust_macros::ensures(
     *result == (*vec).0[index] &&
     !result == (!vec).0[index] &&
-    !vec == thrust_models::model::Vec((*vec).0.store(index, !result), (*vec).1)
+    !vec == thrust_models::model::Seq((*vec).0.store(index, !result), (*vec).1)
 )]
 fn _extern_spec_vec_index_mut<T>(vec: &mut Vec<T>, index: usize) -> &mut T
     where T: thrust_models::Model, T::Ty: PartialEq
@@ -799,7 +786,7 @@ fn _extern_spec_vec_is_empty<T>(vec: &Vec<T>) -> bool where T: thrust_models::Mo
 #[thrust_macros::ensures(
     (
         (*vec).1 > len &&
-        !vec == thrust_models::model::Vec((*vec).0, len)
+        !vec == thrust_models::model::Seq((*vec).0, len)
     ) || (
         (*vec).1 <= len &&
         !vec == *vec

--- a/std.rs
+++ b/std.rs
@@ -196,11 +196,6 @@ mod thrust_models {
             }
         }
 
-        /// `Seq<T>` is the ghost sequence type used in specifications.
-        /// Like `Vec`, it is represented logically as `(Array<Int, T>, Int)`
-        /// — the array carries elements, the int carries length. Concrete
-        /// operations (indexing, push, concat, …) are added incrementally
-        /// in follow-up commits.
         #[thrust::def::seq_model]
         pub struct Seq<T: ?Sized>(pub Array<Int, T>, pub Int);
 
@@ -209,6 +204,46 @@ mod thrust_models {
             fn eq(&self, _other: &U) -> bool {
                 unimplemented!()
             }
+        }
+
+        impl<T, U> std::ops::Index<U> for Seq<T> where U: super::Model<Ty = Int> {
+            type Output = T;
+
+            #[thrust::ignored]
+            fn index(&self, _index: U) -> &Self::Output {
+                unimplemented!()
+            }
+        }
+
+        impl<T> Seq<T> {
+            #[allow(dead_code)]
+            #[thrust::def::seq_empty]
+            #[thrust::ignored]
+            pub fn empty() -> Self {
+                unimplemented!()
+            }
+
+            #[allow(dead_code)]
+            #[thrust::def::seq_singleton]
+            #[thrust::ignored]
+            pub fn singleton(_x: T) -> Self {
+                unimplemented!()
+            }
+
+            #[allow(dead_code)]
+            #[thrust::def::seq_len]
+            #[thrust::ignored]
+            pub fn len(&self) -> Int {
+                unimplemented!()
+            }
+
+            #[allow(dead_code)]
+            #[thrust::def::seq_push]
+            #[thrust::ignored]
+            pub fn push(self, _x: T) -> Self {
+                unimplemented!()
+            }
+
         }
     }
 

--- a/std.rs
+++ b/std.rs
@@ -195,6 +195,25 @@ mod thrust_models {
                 unimplemented!()
             }
         }
+
+        /// `Seq<T>` is the ghost sequence type used in specifications.
+        /// Like `Vec`, it is represented logically as `(Array<Int, T>, Int)`
+        /// — the array carries elements, the int carries length. Concrete
+        /// operations (indexing, push, concat, …) are added incrementally
+        /// in follow-up commits.
+        #[thrust::def::seq_model]
+        pub struct Seq<T: ?Sized>(pub Array<Int, T>, pub Int);
+
+        impl<T, U> PartialEq<U> for Seq<T> where U: super::Model<Ty = Self> {
+            #[thrust::ignored]
+            fn eq(&self, _other: &U) -> bool {
+                unimplemented!()
+            }
+        }
+    }
+
+    impl<T> Model for model::Seq<T> where T: Model {
+        type Ty = model::Seq<<T as Model>::Ty>;
     }
 
     impl Model for model::Int {

--- a/std.rs
+++ b/std.rs
@@ -244,6 +244,12 @@ mod thrust_models {
                 unimplemented!()
             }
 
+            #[allow(dead_code)]
+            #[thrust::def::seq_concat]
+            #[thrust::ignored]
+            pub fn concat(self, _other: Self) -> Self {
+                unimplemented!()
+            }
         }
     }
 

--- a/tests/ui/fail/seq_basic.rs
+++ b/tests/ui/fail/seq_basic.rs
@@ -1,0 +1,20 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+use thrust_models::model::{Int, Seq};
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    Seq::<Int>::empty().len() == 0
+        && Seq::singleton(x).len() == 1
+        && Seq::singleton(x)[0] == x
+        // wrong: should be s.len() + 1
+        && s.push(x).len() == s.len() + 2
+        && s.push(x)[s.len()] == x
+)]
+fn seq_basic(s: Seq<Int>, x: Int) -> () {
+    let _ = s;
+    let _ = x;
+}
+
+fn main() {}

--- a/tests/ui/fail/seq_concat.rs
+++ b/tests/ui/fail/seq_concat.rs
@@ -1,0 +1,13 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+use thrust_models::model::{Int, Seq};
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(s.concat(t).len() == s.len() + t.len() + 1)]
+fn concat_lengths_add(s: Seq<Int>, t: Seq<Int>) -> () {
+    let _ = s;
+    let _ = t;
+}
+
+fn main() {}

--- a/tests/ui/fail/seq_concat_const.rs
+++ b/tests/ui/fail/seq_concat_const.rs
@@ -1,0 +1,16 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::model::{Int, Seq};
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    // wrong: empty.concat(singleton(x)) is singleton(x), not empty
+    Seq::<Int>::empty().concat(Seq::singleton(x)) == Seq::<Int>::empty()
+)]
+fn concat_eq_singleton(x: Int) -> () {
+    let _ = x;
+}
+
+fn main() {}

--- a/tests/ui/fail/seq_concat_index.rs
+++ b/tests/ui/fail/seq_concat_index.rs
@@ -1,0 +1,15 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::model::{Int, Seq};
+
+#[thrust_macros::requires(0 <= i && i < s.len())]
+#[thrust_macros::ensures(s.concat(t)[i] == t[i])]
+fn concat_index_left(s: Seq<Int>, t: Seq<Int>, i: Int) -> () {
+    let _ = s;
+    let _ = t;
+    let _ = i;
+}
+
+fn main() {}

--- a/tests/ui/fail/seq_specs_vec_build.rs
+++ b/tests/ui/fail/seq_specs_vec_build.rs
@@ -1,0 +1,23 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::model::Seq;
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    result.1 == Seq::empty().push(10).push(20).push(30).len()
+        && result.0[0] == Seq::empty().push(10).push(20).push(30)[0]
+        && result.0[1] == Seq::empty().push(10).push(20).push(30)[1]
+        // wrong: last element should be 30, not 99
+        && result.0[2] == Seq::empty().push(10).push(20).push(99)[2]
+)]
+fn build_three() -> Vec<i64> {
+    let mut v = Vec::new();
+    v.push(10);
+    v.push(20);
+    v.push(30);
+    v
+}
+
+fn main() {}

--- a/tests/ui/pass/seq_basic.rs
+++ b/tests/ui/pass/seq_basic.rs
@@ -1,0 +1,19 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+use thrust_models::model::{Int, Seq};
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    Seq::<Int>::empty().len() == 0
+        && Seq::singleton(x).len() == 1
+        && Seq::singleton(x)[0] == x
+        && s.push(x).len() == s.len() + 1
+        && s.push(x)[s.len()] == x
+)]
+fn seq_basic(s: Seq<Int>, x: Int) -> () {
+    let _ = s;
+    let _ = x;
+}
+
+fn main() {}

--- a/tests/ui/pass/seq_concat.rs
+++ b/tests/ui/pass/seq_concat.rs
@@ -1,0 +1,13 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+use thrust_models::model::{Int, Seq};
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(s.concat(t).len() == s.len() + t.len())]
+fn concat_lengths_add(s: Seq<Int>, t: Seq<Int>) -> () {
+    let _ = s;
+    let _ = t;
+}
+
+fn main() {}

--- a/tests/ui/pass/seq_concat_const.rs
+++ b/tests/ui/pass/seq_concat_const.rs
@@ -1,0 +1,16 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::model::{Int, Seq};
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    Seq::singleton(x).concat(Seq::empty()) == Seq::singleton(x)
+        && Seq::empty().concat(Seq::singleton(x)) == Seq::singleton(x)
+)]
+fn concat_eq_singleton(x: Int) -> () {
+    let _ = x;
+}
+
+fn main() {}

--- a/tests/ui/pass/seq_concat_index.rs
+++ b/tests/ui/pass/seq_concat_index.rs
@@ -1,0 +1,15 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::model::{Int, Seq};
+
+#[thrust_macros::requires(0 <= i && i < s.len())]
+#[thrust_macros::ensures(s.concat(t)[i] == s[i])]
+fn concat_index_left(s: Seq<Int>, t: Seq<Int>, i: Int) -> () {
+    let _ = s;
+    let _ = t;
+    let _ = i;
+}
+
+fn main() {}

--- a/tests/ui/pass/seq_specs_vec_build.rs
+++ b/tests/ui/pass/seq_specs_vec_build.rs
@@ -1,0 +1,28 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::model::Seq;
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    result.1 == Seq::empty().push(10).push(20).push(30).len()
+        && result.0[0] == Seq::empty().push(10).push(20).push(30)[0]
+        && result.0[1] == Seq::empty().push(10).push(20).push(30)[1]
+        && result.0[2] == Seq::empty().push(10).push(20).push(30)[2]
+)]
+fn build_three() -> Vec<i64> {
+    let mut v = Vec::new();
+    v.push(10);
+    v.push(20);
+    v.push(30);
+    v
+}
+
+fn main() {
+    let v = build_three();
+    assert!(v.len() == 3);
+    assert!(v[0] == 10);
+    assert!(v[1] == 20);
+    assert!(v[2] == 30);
+}


### PR DESCRIPTION
Introduces thrust_models::model::Seq<T> as (Array<Int, T>, Int), equipped with basic sequence operations and concatenation.

https://claude.ai/code/session_01A7nMxM1sJ8wxVJmMvsEvSX