### PR TITLE
ci: pin Z3 to 4.15.4, the latest version without mut_recursive timeout

### DIFF
--- a/.github/actions/setup-z3/action.yml
+++ b/.github/actions/setup-z3/action.yml
@@ -4,7 +4,7 @@ inputs:
   z3-version:
     description: The version of Z3 to install.
     required: false
-    default: 4.16.0
+    default: 4.15.8
   z3-variant:
     description: The variant of Z3 to install (includes arch, e.g. x64-glibc-2.39, arm64-glibc-2.38).
     required: false
@@ -13,8 +13,8 @@ inputs:
     description: Expected sha256sum of downloaded binary archive.
     required: false
     default: |
-      7288c49a5bd6dbafd7b0b0d1f65956b91672da24b08f09242919af159be3418e  z3-4.16.0-x64-glibc-2.39.zip
-      87fcd963d3eecb0f12cf1c3ef0ad74e84a3a7bd3caed5d94445645ef94ae6274  z3-4.16.0-arm64-glibc-2.38.zip
+      08a3312ef3a632c6e203c07ebdf19ef42f4975c1bd077e25501d204f674542fd  z3-4.15.8-x64-glibc-2.39.zip
+      5d2e5e63018827b9611c15e1bfa48ffd9c0eaeeda6bdf184fd0963cbc0471528  z3-4.15.8-arm64-glibc-2.38.zip
 runs:
   using: composite
   steps:

--- a/.github/actions/setup-z3/action.yml
+++ b/.github/actions/setup-z3/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: The version of Z3 to install.
     required: false
     default: 4.16.0
+  z3-variant:
+    description: The variant of Z3 to install (includes arch, e.g. x64-glibc-2.39, arm64-glibc-2.38).
+    required: false
+    default: x64-glibc-2.39
   z3-sha256sum:
     description: Expected sha256sum of downloaded binary archive.
     required: false
@@ -14,15 +18,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - id: arch
-      shell: bash
-      run: |
-        ARCH=$(echo "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')
-        echo "z3-arch=$ARCH" >> $GITHUB_OUTPUT
-        case "$ARCH" in
-          arm64) echo "z3-variant=glibc-2.38" >> $GITHUB_OUTPUT ;;
-          *)     echo "z3-variant=glibc-2.39" >> $GITHUB_OUTPUT ;;
-        esac
     - shell: bash
       run: |
         wget -q "$RELEASE_URL/$RELEASE_NAME.zip"
@@ -33,5 +28,5 @@ runs:
         echo ~/.setup-z3/bin >> $GITHUB_PATH
       env:
         RELEASE_URL: https://github.com/Z3Prover/z3/releases/download/z3-${{ inputs.z3-version }}
-        RELEASE_NAME: z3-${{ inputs.z3-version }}-${{ steps.arch.outputs.z3-arch }}-${{ steps.arch.outputs.z3-variant }}
+        RELEASE_NAME: z3-${{ inputs.z3-version }}-${{ inputs.z3-variant }}
         INPUT_Z3_SHA256SUM: ${{ inputs.z3-sha256sum }}

--- a/.github/actions/setup-z3/action.yml
+++ b/.github/actions/setup-z3/action.yml
@@ -4,17 +4,17 @@ inputs:
   z3-version:
     description: The version of Z3 to install.
     required: false
-    default: 4.15.8
+    default: 4.15.4
   z3-variant:
-    description: The variant of Z3 to install (includes arch, e.g. x64-glibc-2.39, arm64-glibc-2.38).
+    description: The variant of Z3 to install (includes arch, e.g. x64-glibc-2.39, arm64-glibc-2.34).
     required: false
     default: x64-glibc-2.39
   z3-sha256sum:
     description: Expected sha256sum of downloaded binary archive.
     required: false
     default: |
-      08a3312ef3a632c6e203c07ebdf19ef42f4975c1bd077e25501d204f674542fd  z3-4.15.8-x64-glibc-2.39.zip
-      5d2e5e63018827b9611c15e1bfa48ffd9c0eaeeda6bdf184fd0963cbc0471528  z3-4.15.8-arm64-glibc-2.38.zip
+      a41b690e89c343931471506cdc6d957b6044a200fd2d240cc017432afdff7d3e  z3-4.15.4-x64-glibc-2.39.zip
+      9e832578e28d9ed51a79b97948728a874854a3c38ee49e7aae05e7d6e0e93508  z3-4.15.4-arm64-glibc-2.34.zip
 runs:
   using: composite
   steps:

--- a/.github/actions/setup-z3/action.yml
+++ b/.github/actions/setup-z3/action.yml
@@ -4,24 +4,25 @@ inputs:
   z3-version:
     description: The version of Z3 to install.
     required: false
-    default: 4.13.0
-  z3-variant:
-    description: The variant of Z3 to install.
-    required: false
-    default: glibc-2.35
+    default: 4.16.0
   z3-sha256sum:
     description: Expected sha256sum of downloaded binary archive.
     required: false
     default: |
-      884e3a411fa11b125522fc35eba3391b772517c047f8064fb4b656d92a73b38c  z3-4.13.0-x64-glibc-2.35.zip
-      bc31ad12446d7db1bd9d0ac82dec9d7b5129b8b8dd6e44b571a83ac6010d2f9b  z3-4.13.0-x64-glibc-2.31.zip
-      50fae93d74689bc3460bec939273cf602a4c6f60a047f2a9cf48f609dc444d48  z3-4.13.0-arm64-glibc-2.35.zip
+      7288c49a5bd6dbafd7b0b0d1f65956b91672da24b08f09242919af159be3418e  z3-4.16.0-x64-glibc-2.39.zip
+      87fcd963d3eecb0f12cf1c3ef0ad74e84a3a7bd3caed5d94445645ef94ae6274  z3-4.16.0-arm64-glibc-2.38.zip
 runs:
   using: composite
   steps:
     - id: arch
       shell: bash
-      run: echo "z3-arch=$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]' >> $GITHUB_OUTPUT
+      run: |
+        ARCH=$(echo "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')
+        echo "z3-arch=$ARCH" >> $GITHUB_OUTPUT
+        case "$ARCH" in
+          arm64) echo "z3-variant=glibc-2.38" >> $GITHUB_OUTPUT ;;
+          *)     echo "z3-variant=glibc-2.39" >> $GITHUB_OUTPUT ;;
+        esac
     - shell: bash
       run: |
         wget -q "$RELEASE_URL/$RELEASE_NAME.zip"
@@ -32,5 +33,5 @@ runs:
         echo ~/.setup-z3/bin >> $GITHUB_PATH
       env:
         RELEASE_URL: https://github.com/Z3Prover/z3/releases/download/z3-${{ inputs.z3-version }}
-        RELEASE_NAME: z3-${{ inputs.z3-version }}-${{ steps.arch.outputs.z3-arch }}-${{ inputs.z3-variant }}
+        RELEASE_NAME: z3-${{ inputs.z3-version }}-${{ steps.arch.outputs.z3-arch }}-${{ steps.arch.outputs.z3-variant }}
         INPUT_Z3_SHA256SUM: ${{ inputs.z3-sha256sum }}


### PR DESCRIPTION
## Summary

- Redesigns the `setup-z3` action so `z3-variant` includes the full platform string (e.g. `x64-glibc-2.39`) instead of just the libc suffix, removing the need for a separate arch-detection step
- Bisected the `mut_recursive` timeout regression to Z3 4.15.5 — versions 4.15.5 through 4.16.0 all timeout; 4.15.4 and earlier pass
- Pins Z3 to **4.15.4** with verified checksums from the official release page

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLvxRwp1ZRCVP3X4JDithT)_