### PR TITLE
Add slice construction from array literals

### DIFF
--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -479,6 +479,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     fn rvalue_type(&mut self, rvalue: Rvalue<'tcx>) -> PlaceType {
         match rvalue {
             Rvalue::Use(operand) => self.operand_type(operand),
+            Rvalue::CopyForDeref(place) => self.env.place_type(self.elaborate_place(&place)),
             Rvalue::UnaryOp(op, operand) => {
                 let operand_ty = self.operand_type(operand);
 
@@ -649,6 +650,20 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                     _ => unimplemented!(),
                 };
                 PlaceType::with_ty_and_term(func_ty.vacuous(), chc::Term::null())
+            }
+            Rvalue::Cast(
+                mir::CastKind::PointerCoercion(mir_ty::adjustment::PointerCoercion::Unsize, _),
+                operand,
+                ty,
+            ) => {
+                // Only treat unsizing as identity when both sides resolve to the same model.
+                let mut op_pty = self.operand_type(operand);
+                let expected_ty = self.type_builder.build(ty).vacuous();
+                if op_pty.ty.to_sort() != expected_ty.to_sort() {
+                    unimplemented!("unsize cast: {:?} -> {:?}", op_pty.ty, expected_ty);
+                }
+                op_pty.ty = expected_ty;
+                op_pty
             }
             Rvalue::Discriminant(place) => {
                 let place = self.elaborate_place(&place);

--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -454,7 +454,13 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                     .unwrap();
                 self.const_value_ty(&val, ty)
             }
-            _ => unimplemented!("const: {:?}", const_),
+            mir::Const::Ty(ty, _) => {
+                let scalar_int = const_
+                    .try_to_scalar_int()
+                    .expect("type-level const must be a primitive scalar");
+                let val = mir::ConstValue::Scalar(mir::interpret::Scalar::Int(scalar_int));
+                self.const_value_ty(&val, ty)
+            }
         }
     }
 
@@ -535,15 +541,41 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                 builder.build(rty::PointerType::immut_to(ty).into(), chc::Term::box_(term))
             }
             Rvalue::Aggregate(kind, fields) => {
-                // elaboration: all fields are boxed
-                let field_tys: Vec<_> = fields
-                    .into_iter()
-                    .map(|operand| self.operand_type(operand).boxed())
-                    .collect();
                 match *kind {
+                    mir::AggregateKind::Array(mir_elem_ty) => {
+                        // Build Seq<T> = (Box<Array<Int,T>>, Box<Int>) from array literal elements,
+                        // pinning each element at its index via store folds.
+                        //
+                        // TODO: Stop embedding knowledge of `<[T; N] as Model>::Ty` in the analyzer
+                        let mut builder = PlaceTypeBuilder::default();
+                        let elem_ty = self.type_builder.build(mir_elem_ty).vacuous();
+                        let mut arr_term =
+                            chc::Term::array_empty(chc::Sort::int(), elem_ty.to_sort());
+                        for (i, field) in fields.iter().enumerate() {
+                            let pty = self.operand_type(field.clone());
+                            let (_, elem_term) = builder.subsume(pty);
+                            arr_term = arr_term.store(chc::Term::int(i as i64), elem_term);
+                        }
+                        let arr_pty = builder.build(
+                            rty::ArrayType::new(rty::Type::int(), elem_ty).into(),
+                            arr_term,
+                        );
+                        let size = fields.len();
+                        let size_pty = PlaceType::with_ty_and_term(
+                            rty::Type::int(),
+                            chc::Term::int(size as i64),
+                        );
+                        PlaceType::tuple(vec![arr_pty.boxed(), size_pty.boxed()])
+                    }
                     mir::AggregateKind::Adt(did, variant_idx, args, _, _)
                         if self.tcx.def_kind(did) == DefKind::Enum =>
                     {
+                        // elaboration: all fields are boxed
+                        let field_tys: Vec<_> = fields
+                            .into_iter()
+                            .map(|operand| self.operand_type(operand).boxed())
+                            .collect();
+
                         let enum_def = self.ctx.get_or_register_enum_def(did);
                         let variant_def = &enum_def.variants[variant_idx];
                         let variant_rtys = variant_def
@@ -591,7 +623,17 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
                             ),
                         )
                     }
-                    _ => PlaceType::tuple(field_tys),
+                    mir::AggregateKind::Adt { .. }
+                    | mir::AggregateKind::Tuple
+                    | mir::AggregateKind::Closure { .. } => {
+                        // elaboration: all fields are boxed
+                        let field_tys: Vec<_> = fields
+                            .into_iter()
+                            .map(|operand| self.operand_type(operand).boxed())
+                            .collect();
+                        PlaceType::tuple(field_tys)
+                    }
+                    _ => unimplemented!("aggregate kind: {:?}", kind),
                 }
             }
             Rvalue::Cast(

--- a/src/analyze/reconstruct_slice_indexing.rs
+++ b/src/analyze/reconstruct_slice_indexing.rs
@@ -269,7 +269,7 @@ fn reconstruct_access<'tcx>(
         result_local,
     );
     let receiver = receiver_operand(tcx, body, &bounds_check, &access, region);
-    remove_bounds_check_setup(body, &bounds_check);
+    remove_bounds_check_setup(body, &bounds_check, access.receiver.local);
 
     let (lang_item, method_name) = if access.mutable {
         (LangItem::IndexMut, sym::index_mut)
@@ -358,7 +358,11 @@ fn receiver_operand<'tcx>(
 }
 
 /// Removes the MIR temporaries that only supported the now-replaced bounds check.
-fn remove_bounds_check_setup<'tcx>(body: &mut Body<'tcx>, bounds_check: &BoundsCheck<'tcx>) {
+fn remove_bounds_check_setup<'tcx>(
+    body: &mut Body<'tcx>,
+    bounds_check: &BoundsCheck<'tcx>,
+    receiver_local: Local,
+) {
     let mut lowered_locals: Vec<_> = bounds_check.condition_local.into_iter().collect();
     if let Some(len_place) = bounds_check
         .len
@@ -373,7 +377,13 @@ fn remove_bounds_check_setup<'tcx>(body: &mut Body<'tcx>, bounds_check: &BoundsC
                 continue;
             };
             if lhs.local == len_place.local {
-                if let Some(raw_place) = operand.place().filter(|place| place.projection.is_empty())
+                // Only include the PtrMetadata operand if it is a distinct temporary — i.e.
+                // not the receiver that the reconstructed Index::index call will use.
+                // When PtrMetadata is applied directly to the slice reference (the receiver),
+                // that local must not be NOP'd: its assignment may be in this same block.
+                if let Some(raw_place) = operand
+                    .place()
+                    .filter(|place| place.projection.is_empty() && place.local != receiver_local)
                 {
                     lowered_locals.push(raw_place.local);
                 }

--- a/std.rs
+++ b/std.rs
@@ -368,6 +368,11 @@ mod thrust_models {
         type Ty = model::Seq<<T as Model>::Ty>;
     }
 
+    // NOTE: basic_block::Analyzer depends on the structure of array model
+    impl<T: Model, const N: usize> Model for [T; N] {
+        type Ty = model::Seq<<T as Model>::Ty>;
+    }
+
     impl<T> Model for Option<T> where T: Model {
         type Ty = Option<<T as Model>::Ty>;
     }

--- a/tests/ui/fail/array_literal_1.rs
+++ b/tests/ui/fail/array_literal_1.rs
@@ -1,0 +1,9 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+fn main() {
+    let arr = [1i32, 2, 3];
+    let s: &[i32] = &arr;
+    let v = s[0];
+    assert!(v == 99);
+}

--- a/tests/ui/fail/array_literal_2.rs
+++ b/tests/ui/fail/array_literal_2.rs
@@ -1,0 +1,8 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+fn main() {
+    let arr = [0i32, 0, 0, 0];
+    let s: &[i32] = &arr;
+    let _ = s[4];
+}

--- a/tests/ui/fail/array_literal_3.rs
+++ b/tests/ui/fail/array_literal_3.rs
@@ -1,0 +1,9 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+fn main() {
+    let mut arr = [1i32, 2, 3];
+    let s: &mut [i32] = &mut arr;
+    s[0] = 42;
+    assert!(s[0] == 1); // old value → Unsat
+}

--- a/tests/ui/pass/array_literal_1.rs
+++ b/tests/ui/pass/array_literal_1.rs
@@ -1,0 +1,9 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+fn main() {
+    let arr = [1i32, 2, 3];
+    let s: &[i32] = &arr;
+    let v = s[0];
+    assert!(v == 1);
+}

--- a/tests/ui/pass/array_literal_2.rs
+++ b/tests/ui/pass/array_literal_2.rs
@@ -1,0 +1,8 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+fn main() {
+    let arr = [0i32, 0, 0, 0];
+    let s: &[i32] = &arr;
+    let _ = s[3];
+}

--- a/tests/ui/pass/array_literal_3.rs
+++ b/tests/ui/pass/array_literal_3.rs
@@ -1,0 +1,10 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+fn main() {
+    let mut arr = [1i32, 2, 3];
+    let s: &mut [i32] = &mut arr;
+    s[0] = 42;
+    assert!(s[0] == 42);
+    assert!(s[1] == 2);
+}


### PR DESCRIPTION
Adds support for constructing `&[T]` slices from array literals (`[T; N]`) and indexing through them with full refinement-type tracking.

## Changes

### `src/analyze/basic_block.rs`

- **`AggregateKind::Array`**: Build the `Seq<T>` model from array literal elements by folding `store` calls to pin each element at its index and recording the static length. This is intentionally model-aware — following the precedent of Verus, Prusti, and Creusot, array literal construction is a primitive whose semantics the verifier encodes directly (analogous to integer arithmetic), rather than routing through user-visible extern specs.
- **`Rvalue::CopyForDeref`**: Delegate to `env.place_type` (same as `Use`).
- **`Rvalue::Cast(PointerCoercion::Unsize)`**: Identity pass-through for `&[T; N] → &[T]` (both share the same `Seq<T>` model).
- **`mir::Const::Ty`**: Handle type-level constants (const generics, e.g. array length `N`) by extracting their scalar value.

### `src/analyze/reconstruct_slice_indexing.rs`

- **Bug fix**: `remove_bounds_check_setup` was incorrectly NOP'ing the slice receiver local when `PtrMetadata` was applied directly to it (rather than to a raw-pointer temporary). This caused the receiver's assignment to be erased in-block, making it appear live-in to the entry block, and ultimately panicking in `Instantiator::instantiate` when a synthetic unit parameter carried a `RefinedTypeVar::Value` refinement with `value_var = None`. Fix: skip `raw_place.local` when it equals the receiver local.

### `std.rs`

- **`[T; N]` model**: `impl<T: Model, const N: usize> Model for [T; N]` mapping to `model::Seq<T::Ty>`, consistent with `[T]`.

## Tests

6 new UI tests (3 pass / 3 fail):

| Test | What it checks |
|------|----------------|
| `pass/array_literal_1.rs` | Build `[1i32, 2, 3]`, coerce to `&[i32]`, assert `s[0] == 1` |
| `pass/array_literal_2.rs` | 4-element array, access last element |
| `pass/array_literal_3.rs` | `&mut [i32]`, write through slice, verify updated value |
| `fail/array_literal_1.rs` | Wrong expected value → Unsat |
| `fail/array_literal_2.rs` | Out-of-bounds index → Unsat |
| `fail/array_literal_3.rs` | Read stale value after write → Unsat |