### PR TITLE
Add Vec-to-slice coercion extern specs

### DIFF
--- a/std.rs
+++ b/std.rs
@@ -802,6 +802,33 @@ fn _extern_spec_vec_truncate<T>(vec: &mut Vec<T>, len: usize) where T: thrust_mo
 
 #[thrust::extern_spec_fn]
 #[thrust_macros::requires(true)]
+#[thrust_macros::ensures(*result == *vec)]
+fn _extern_spec_vec_as_slice<T>(vec: &Vec<T>) -> &[T]
+    where T: thrust_models::Model, T::Ty: PartialEq
+{
+    Vec::as_slice(vec)
+}
+
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(*result == *vec)]
+fn _extern_spec_vec_deref<T>(vec: &Vec<T>) -> &[T]
+    where T: thrust_models::Model, T::Ty: PartialEq
+{
+    <Vec<T> as std::ops::Deref>::deref(vec)
+}
+
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(*result == *vec)]
+fn _extern_spec_vec_as_ref<T>(vec: &Vec<T>) -> &[T]
+    where T: thrust_models::Model, T::Ty: PartialEq
+{
+    <Vec<T> as AsRef<[T]>>::as_ref(vec)
+}
+
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(true)]
 #[thrust_macros::ensures(result == slice.1)]
 fn _extern_spec_slice_len<T>(slice: &[T]) -> usize
     where T: thrust_models::Model, T::Ty: PartialEq

--- a/tests/ui/fail/vec_deref.rs
+++ b/tests/ui/fail/vec_deref.rs
@@ -1,0 +1,10 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+fn main() {
+    let mut v: Vec<i32> = Vec::new();
+    Vec::push(&mut v, 10);
+    Vec::push(&mut v, 20);
+    let s: &[i32] = &v;
+    assert!(s[0] == 99); // wrong value → Unsat
+}

--- a/tests/ui/pass/vec_deref.rs
+++ b/tests/ui/pass/vec_deref.rs
@@ -1,0 +1,12 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+fn main() {
+    let mut v: Vec<i32> = Vec::new();
+    Vec::push(&mut v, 10);
+    Vec::push(&mut v, 20);
+    let s: &[i32] = &v;
+    assert!(s.len() == 2);
+    assert!(s[0] == 10);
+    assert!(s[1] == 20);
+}


### PR DESCRIPTION
Specifies the postcondition `*result == *vec` for the three standard ways a `Vec<T>` can be coerced to `&[T]`, letting the refinement checker propagate Seq refinements through all of them.

## Changes

### `std.rs`

- **`Vec::as_slice`**: explicit call `Vec::as_slice(&v)`
- **`Deref::deref`**: implicit coercion `let s: &[T] = &v`
- **`AsRef::as_ref`**: `v.as_ref()`

All three specs have the postcondition `*result == *vec`.

## Tests

2 new UI tests covering the implicit deref coercion path:

| Test | What it checks |
|------|----------------|
| `pass/vec_deref.rs` | Push 10, 20; implicit `&v` coercion; assert len and element values |
| `fail/vec_deref.rs` | Wrong expected value → Unsat |