### PR TITLE
Add subsequence and slice split operations

### DIFF
--- a/src/analyze/annot.rs
+++ b/src/analyze/annot.rs
@@ -177,6 +177,14 @@ pub fn seq_push_path() -> [Symbol; 3] {
     ]
 }
 
+pub fn seq_subsequence_path() -> [Symbol; 3] {
+    [
+        Symbol::intern("thrust"),
+        Symbol::intern("def"),
+        Symbol::intern("seq_subsequence"),
+    ]
+}
+
 pub fn seq_concat_path() -> [Symbol; 3] {
     [
         Symbol::intern("thrust"),

--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -715,6 +715,21 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
                             new_arr, offset, new_len,
                         ]));
                     }
+                    if Some(def_id) == self.def_ids.seq_subsequence() {
+                        assert_eq!(args.len(), 2, "Seq::subsequence takes exactly 2 arguments");
+                        let t = self.to_term(receiver);
+                        let start = self.to_term(&args[0]);
+                        let end = self.to_term(&args[1]);
+                        let arr = t.clone().tuple_proj(0);
+                        let offset = t.tuple_proj(1);
+                        // A subsequence shares the underlying array, advances the offset by
+                        // `start`, and sets the length to `end - start`.
+                        return FormulaOrTerm::Term(chc::Term::tuple(vec![
+                            arr,
+                            offset.add(start.clone()),
+                            end.sub(start),
+                        ]));
+                    }
                     if Some(def_id) == self.def_ids.seq_concat() {
                         assert_eq!(args.len(), 1, "Seq::concat takes exactly 1 argument");
                         let elem_sort = self.adt_arg_type_at(receiver, 0).to_sort();

--- a/src/analyze/did_cache.rs
+++ b/src/analyze/did_cache.rs
@@ -29,6 +29,7 @@ struct DefIds {
     seq_singleton: OnceCell<Option<DefId>>,
     seq_len: OnceCell<Option<DefId>>,
     seq_push: OnceCell<Option<DefId>>,
+    seq_subsequence: OnceCell<Option<DefId>>,
     seq_concat: OnceCell<Option<DefId>>,
 
     exists: OnceCell<Option<DefId>>,
@@ -219,6 +220,13 @@ impl<'tcx> DefIdCache<'tcx> {
             .def_ids
             .seq_push
             .get_or_init(|| self.annotated_def(&crate::analyze::annot::seq_push_path()))
+    }
+
+    pub fn seq_subsequence(&self) -> Option<DefId> {
+        *self
+            .def_ids
+            .seq_subsequence
+            .get_or_init(|| self.annotated_def(&crate::analyze::annot::seq_subsequence_path()))
     }
 
     pub fn seq_concat(&self) -> Option<DefId> {

--- a/std.rs
+++ b/std.rs
@@ -240,6 +240,17 @@ mod thrust_models {
             }
 
             #[allow(dead_code)]
+            #[thrust::def::seq_subsequence]
+            #[thrust::ignored]
+            pub fn subsequence<U, V>(self, _start: U, _end: V) -> Self
+            where
+                U: super::Model<Ty = Int>,
+                V: super::Model<Ty = Int>,
+            {
+                unimplemented!()
+            }
+
+            #[allow(dead_code)]
             #[thrust::def::seq_concat]
             #[thrust::ignored]
             pub fn concat(self, _other: Self) -> Self {

--- a/std.rs
+++ b/std.rs
@@ -1006,6 +1006,53 @@ fn _extern_spec_slice_split_last<T>(slice: &[T]) -> Option<(&T, &[T])>
     <[T]>::split_last(slice)
 }
 
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    ((*slice).length > 0
+        && (!slice).offset == (*slice).offset
+        && (!slice).length == (*slice).length
+        && result == Some((
+            thrust_models::model::Mut::new((*slice)[0], (!slice)[0]),
+            thrust_models::model::Mut::new(
+                (*slice).subsequence(1, (*slice).length),
+                (!slice).subsequence(1, (!slice).length),
+            ),
+        ))
+    )
+    || ((*slice).length == 0 && result == None && !slice == *slice)
+)]
+fn _extern_spec_slice_split_first_mut<T>(slice: &mut [T]) -> Option<(&mut T, &mut [T])>
+    where T: thrust_models::Model, T::Ty: PartialEq
+{
+    <[T]>::split_first_mut(slice)
+}
+
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    ((*slice).length > 0
+        && (!slice).offset == (*slice).offset
+        && (!slice).length == (*slice).length
+        && result == Some((
+            thrust_models::model::Mut::new(
+                (*slice)[(*slice).length - 1],
+                (!slice)[(!slice).length - 1],
+            ),
+            thrust_models::model::Mut::new(
+                (*slice).subsequence(0, (*slice).length - 1),
+                (!slice).subsequence(0, (!slice).length - 1),
+            ),
+        ))
+    )
+    || ((*slice).length == 0 && result == None && !slice == *slice)
+)]
+fn _extern_spec_slice_split_last_mut<T>(slice: &mut [T]) -> Option<(&mut T, &mut [T])>
+    where T: thrust_models::Model, T::Ty: PartialEq
+{
+    <[T]>::split_last_mut(slice)
+}
+
 // TODO: The following specs for Index/IndexMut methods are too specific; we should write specs for
 //       a generic index (I: SliceIndex) that isn't specific to usize, maybe once #83 is implemented.
 

--- a/std.rs
+++ b/std.rs
@@ -972,6 +972,40 @@ fn _extern_spec_slice_last_mut<T>(slice: &mut [T]) -> Option<&mut T>
     <[T]>::last_mut(slice)
 }
 
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    ((*slice).length > 0
+        && result == Some((
+            &(*slice).array[(*slice).offset],
+            &(*slice).subsequence(1, (*slice).length),
+        ))
+    )
+    || ((*slice).length == 0 && result == None)
+)]
+fn _extern_spec_slice_split_first<T>(slice: &[T]) -> Option<(&T, &[T])>
+    where T: thrust_models::Model, T::Ty: PartialEq
+{
+    <[T]>::split_first(slice)
+}
+
+#[thrust::extern_spec_fn]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    ((*slice).length > 0
+        && result == Some((
+            &(*slice).array[(*slice).offset + (*slice).length - 1],
+            &(*slice).subsequence(0, (*slice).length - 1),
+        ))
+    )
+    || ((*slice).length == 0 && result == None)
+)]
+fn _extern_spec_slice_split_last<T>(slice: &[T]) -> Option<(&T, &[T])>
+    where T: thrust_models::Model, T::Ty: PartialEq
+{
+    <[T]>::split_last(slice)
+}
+
 // TODO: The following specs for Index/IndexMut methods are too specific; we should write specs for
 //       a generic index (I: SliceIndex) that isn't specific to usize, maybe once #83 is implemented.
 

--- a/tests/ui/fail/slice_split_first.rs
+++ b/tests/ui/fail/slice_split_first.rs
@@ -1,0 +1,19 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    (*result).length == 2
+        && (*result).array[(*result).offset] == 10
+        && (*result).array[(*result).offset + 1] == 20
+)]
+fn slice() -> &'static [i32] {
+    unimplemented!()
+}
+
+fn main() {
+    let slice = slice();
+    let (first, _tail) = slice.split_first().unwrap();
+    // wrong: the first element is 10, not 11
+    assert!(*first == 11);
+}

--- a/tests/ui/fail/slice_split_first_mut.rs
+++ b/tests/ui/fail/slice_split_first_mut.rs
@@ -1,0 +1,19 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    (*result).length == 2
+        && (*result).array[(*result).offset] == 10
+        && (*result).array[(*result).offset + 1] == 20
+)]
+fn slice() -> &'static mut [i32] {
+    unimplemented!()
+}
+
+fn main() {
+    let slice = slice();
+    let (first, _tail) = slice.split_first_mut().unwrap();
+    // wrong: the first element is 10, not 11
+    assert!(*first == 11);
+}

--- a/tests/ui/fail/slice_split_first_mut_mutation_unsound.rs
+++ b/tests/ui/fail/slice_split_first_mut_mutation_unsound.rs
@@ -1,0 +1,28 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+// KNOWN LIMITATION: mutation through a `&mut` returned inside a tuple (as
+// `split_first_mut` does) does not currently propagate back to the original
+// slice, which is unsound. This test is expected to be rejected (`Unsat`) once
+// that is fixed; it is kept here as a reproduction until the fix lands.
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    (*result).length == 2
+        && (*result).array[(*result).offset] == 10
+        && (*result).array[(*result).offset + 1] == 20
+)]
+fn slice() -> &'static mut [i32] {
+    unimplemented!()
+}
+
+fn main() {
+    let slice = slice();
+    {
+        // Destructure the returned tuple, then mutate through its first reference.
+        let (first, _tail) = slice.split_first_mut().unwrap();
+        *first = 11;
+    }
+    // The mutation makes slice[0] equal to 11, so this must be rejected.
+    assert!(slice[0] == 12);
+}

--- a/tests/ui/fail/slice_split_last.rs
+++ b/tests/ui/fail/slice_split_last.rs
@@ -1,0 +1,19 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    (*result).length == 2
+        && (*result).array[(*result).offset] == 10
+        && (*result).array[(*result).offset + 1] == 20
+)]
+fn slice() -> &'static [i32] {
+    unimplemented!()
+}
+
+fn main() {
+    let slice = slice();
+    let (last, _init) = slice.split_last().unwrap();
+    // wrong: the last element is 20, not 21
+    assert!(*last == 21);
+}

--- a/tests/ui/fail/slice_split_last_mut.rs
+++ b/tests/ui/fail/slice_split_last_mut.rs
@@ -1,0 +1,19 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    (*result).length == 2
+        && (*result).array[(*result).offset] == 10
+        && (*result).array[(*result).offset + 1] == 20
+)]
+fn slice() -> &'static mut [i32] {
+    unimplemented!()
+}
+
+fn main() {
+    let slice = slice();
+    let (last, _init) = slice.split_last_mut().unwrap();
+    // wrong: the last element is 20, not 21
+    assert!(*last == 21);
+}

--- a/tests/ui/pass/slice_split_first.rs
+++ b/tests/ui/pass/slice_split_first.rs
@@ -1,0 +1,20 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    (*result).length == 2
+        && (*result).array[(*result).offset] == 10
+        && (*result).array[(*result).offset + 1] == 20
+)]
+fn slice() -> &'static [i32] {
+    unimplemented!()
+}
+
+fn main() {
+    let slice = slice();
+    let (first, tail) = slice.split_first().unwrap();
+    assert!(*first == 10);
+    assert!(tail.len() == 1);
+    assert!(*tail.first().unwrap() == 20);
+}

--- a/tests/ui/pass/slice_split_first_mut.rs
+++ b/tests/ui/pass/slice_split_first_mut.rs
@@ -1,0 +1,20 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    (*result).length == 2
+        && (*result).array[(*result).offset] == 10
+        && (*result).array[(*result).offset + 1] == 20
+)]
+fn slice() -> &'static mut [i32] {
+    unimplemented!()
+}
+
+fn main() {
+    let slice = slice();
+    let (first, tail) = slice.split_first_mut().unwrap();
+    assert!(*first == 10);
+    assert!(tail.len() == 1);
+    assert!(*tail.first().unwrap() == 20);
+}

--- a/tests/ui/pass/slice_split_last.rs
+++ b/tests/ui/pass/slice_split_last.rs
@@ -1,0 +1,20 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    (*result).length == 2
+        && (*result).array[(*result).offset] == 10
+        && (*result).array[(*result).offset + 1] == 20
+)]
+fn slice() -> &'static [i32] {
+    unimplemented!()
+}
+
+fn main() {
+    let slice = slice();
+    let (last, init) = slice.split_last().unwrap();
+    assert!(*last == 20);
+    assert!(init.len() == 1);
+    assert!(*init.first().unwrap() == 10);
+}

--- a/tests/ui/pass/slice_split_last_mut.rs
+++ b/tests/ui/pass/slice_split_last_mut.rs
@@ -1,0 +1,20 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(
+    (*result).length == 2
+        && (*result).array[(*result).offset] == 10
+        && (*result).array[(*result).offset + 1] == 20
+)]
+fn slice() -> &'static mut [i32] {
+    unimplemented!()
+}
+
+fn main() {
+    let slice = slice();
+    let (last, init) = slice.split_last_mut().unwrap();
+    assert!(*last == 20);
+    assert!(init.len() == 1);
+    assert!(*init.first().unwrap() == 10);
+}


### PR DESCRIPTION
## Summary

**PR 4 of 4** restructuring #153. Stacked on top of #163. Contains three commits:

1. **`Seq::subsequence(start, end)`** — a view over the same underlying array with the offset advanced by `start` and the length set to `end - start`. Used to describe the tail/init views of the split operations (no dedicated test — it is exercised through the split tests).
2. **`split_first` / `split_last`** — return the boundary element together with a subsequence view of the rest, with paired pass/fail tests.
3. **`split_first_mut` / `split_last_mut`** — the mutable counterparts, with read-only pass/fail tests.

## Known limitation (expected CI failure)

A mutation through a `&mut` returned inside a tuple (as `split_first_mut` does) is not yet propagated back to the original slice, which is unsound. `tests/ui/fail/slice_split_first_mut_mutation_unsound.rs` reproduces this and is **expected to keep failing** until the fix lands on `main` — it is intentionally left as-is here. See the discussion on #124: https://github.com/coord-e/thrust/pull/124#issuecomment-4825236582

## Validation

- `cargo build`, `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`
- `cargo test` — all new `split_first`/`split_last`(`_mut`) pass/fail tests pass under the default Spacer solver; the only unexpected-looking failure is the intentional unsoundness reproduction above. (PCSat-backed tests require the CoAR Docker image and were not run here.)

## Stack

1. named fields (#161)
2. `concat_int_array` takes sequence tuples (#162)
3. offset field (#163)
4. **this PR** — subsequence + `split_first`/`split_last`(`_mut`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzapTuen2mKHkkN3B7d8qi

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzapTuen2mKHkkN3B7d8qi)_