### PR TITLE
[codex] Carry nonnegative invariant for unsigned integers

### DIFF
--- a/src/refine/basic_block.rs
+++ b/src/refine/basic_block.rs
@@ -139,13 +139,20 @@ impl BasicBlockType {
 
     pub fn set_precondition(&mut self, refinement: rty::Refinement<rty::FunctionParamIdx>) {
         let last_param_idx = self.ty.params.last_index().unwrap();
-        self.ty.params.raw.last_mut().unwrap().refinement = refinement.map_var(|v| {
+        let refinement = refinement.map_var(|v| {
             if v == rty::RefinedTypeVar::Free(last_param_idx) {
                 rty::RefinedTypeVar::Value
             } else {
                 v
             }
         });
+        self.ty
+            .params
+            .raw
+            .last_mut()
+            .unwrap()
+            .refinement
+            .push_conj(refinement);
     }
 
     /// Inner function type of BasicBlockType contains extra parameters that carry original

--- a/src/refine/template.rs
+++ b/src/refine/template.rs
@@ -614,9 +614,34 @@ impl<'tcx, 'a, R> FunctionTemplateTypeBuilder<'tcx, 'a, R>
 where
     R: TemplateRegistry,
 {
+    fn unsigned_type_invariant<V>(
+        mir_ty: mir_ty::Ty<'tcx>,
+        value: chc::Term<rty::RefinedTypeVar<V>>,
+    ) -> Option<rty::Refinement<V>> {
+        matches!(mir_ty.kind(), mir_ty::TyKind::Uint(_)).then(|| {
+            chc::Atom::new(
+                chc::KnownPred::GREATER_THAN_OR_EQUAL.into(),
+                vec![value, chc::Term::int(0)],
+            )
+            .into()
+        })
+    }
+
+    fn add_type_invariant(
+        mir_ty: mir_ty::Ty<'tcx>,
+        rty: &mut rty::RefinedType<rty::FunctionParamIdx>,
+    ) {
+        if let Some(invariant) =
+            Self::unsigned_type_invariant(mir_ty, chc::Term::var(rty::RefinedTypeVar::Value))
+        {
+            rty.refinement.push_conj(invariant);
+        }
+    }
+
     pub fn build(&mut self) -> rty::FunctionType {
         let mut builder = rty::TemplateBuilder::default();
         let mut param_rtys = IndexVec::<rty::FunctionParamIdx, _>::new();
+        let mut param_type_invariants = rty::Refinement::top();
         for (idx, param_ty) in self.param_tys.iter().enumerate() {
             let param_rty = self
                 .param_rtys
@@ -644,6 +669,13 @@ where
                         )
                     }
                 });
+            let mut value = chc::Term::var(rty::RefinedTypeVar::Free(idx.into()));
+            if param_ty.mutbl.is_mut() {
+                value = value.box_current();
+            }
+            if let Some(invariant) = Self::unsigned_type_invariant(param_ty.ty, value) {
+                param_type_invariants.push_conj(invariant);
+            }
             let param_rty = if param_ty.mutbl.is_mut() {
                 // elaboration: treat mutabully declared variables as own
                 param_rty.boxed()
@@ -669,12 +701,25 @@ where
             param_rtys.push(param_rty);
         }
 
-        let ret_rty = self.ret_rty.clone().unwrap_or_else(|| {
+        let last_param_idx = param_rtys.last_index().unwrap();
+        let type_invariants = param_type_invariants.map_var(|v| match v {
+            rty::RefinedTypeVar::Free(idx) if idx == last_param_idx => rty::RefinedTypeVar::Value,
+            v => v,
+        });
+        param_rtys
+            .raw
+            .last_mut()
+            .unwrap()
+            .refinement
+            .push_conj(type_invariants);
+
+        let mut ret_rty = self.ret_rty.clone().unwrap_or_else(|| {
             self.inner
                 .for_template(self.registry)
                 .with_scope(&builder)
                 .build_refined(self.ret_ty)
         });
+        Self::add_type_invariant(self.ret_ty, &mut ret_rty);
         rty::FunctionType::new(param_rtys, ret_rty).with_abi(self.abi)
     }
 }

--- a/tests/ui/fail/loop_invariant_unsigned.rs
+++ b/tests/ui/fail/loop_invariant_unsigned.rs
@@ -1,0 +1,24 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand() -> bool { unimplemented!() }
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand_u32() -> u32 { unimplemented!() }
+
+fn carry_positive(mut x: u32) -> u32 {
+    while rand() {
+        thrust_macros::invariant!(|x: u32| x >= 1);
+        x = x + 1;
+    }
+    x
+}
+
+fn main() {
+    let _ = carry_positive(rand_u32());
+}

--- a/tests/ui/pass/loop_invariant_unsigned.rs
+++ b/tests/ui/pass/loop_invariant_unsigned.rs
@@ -1,0 +1,24 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand() -> bool { unimplemented!() }
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand_u32() -> u32 { unimplemented!() }
+
+fn carry_nonnegative(mut x: u32) -> u32 {
+    while rand() {
+        thrust_macros::invariant!(|x: u32| x >= 0);
+        x = x + 1;
+    }
+    x
+}
+
+fn main() {
+    let _ = carry_nonnegative(rand_u32());
+}


### PR DESCRIPTION
## Summary

- add `0 <= x` as an intrinsic refinement for unsigned integer parameters and return values
- aggregate unsigned parameter refinements into the function/basic-block precondition
- preserve intrinsic refinements when installing inferred or explicit basic-block preconditions
- add a regression test for carrying `x >= 0` as a `u32` loop invariant

## Motivation

Thrust models signed and unsigned Rust integers with the same unbounded integer sort. As a result, an unconstrained `u32` was not known to be nonnegative, so a loop invariant such as `x >= 0` could not be established from the Rust type.

This change keeps the unbounded-integer model while adding the selected unsigned type invariant `0 <= x`. It does not model unsigned upper bounds or wrapping arithmetic.

## Validation

- `cargo fmt --check`
- `cargo test --lib`
- `cargo test --test ui loop_invariant_unsigned` with the repository solver wrapper
- full UI suite reviewed by the repository owner
