### PR TITLE
Be sure to check trait-impl methods against the trait method's spec

### DIFF
--- a/src/analyze/crate_.rs
+++ b/src/analyze/crate_.rs
@@ -60,13 +60,23 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     }
 
     fn refine_local_defs(&mut self) {
+        // Prioritize trait method specs so that they are always available when refining trait impl
+        // functions; see the partialeq_impl.rs case.
         let mut keys = self.tcx.mir_keys(()).clone();
+        let mut trait_method_spec_keys = HashSet::new();
         for local_def_id in self.tcx.mir_keys(()) {
             let analyzer = self.ctx.local_def_analyzer(*local_def_id);
             if analyzer.is_annotated_as_extern_spec_fn() {
                 let target_def_id = analyzer.extern_spec_fn_target_def_id();
                 if let Some(local_target_def_id) = target_def_id.as_local() {
                     keys.swap_remove(&local_target_def_id);
+                }
+                if matches!(
+                    self.tcx.def_kind(target_def_id),
+                    rustc_hir::def::DefKind::AssocFn
+                ) {
+                    trait_method_spec_keys.insert(*local_def_id);
+                    keys.swap_remove(local_def_id);
                 }
             }
             if analyzer.is_annotated_as_ignored() {
@@ -86,6 +96,9 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             if !self.tcx.def_kind(*local_def_id).is_fn_like() {
                 keys.swap_remove(local_def_id);
             }
+        }
+        for local_def_id in &trait_method_spec_keys {
+            self.refine_fn_def(*local_def_id);
         }
         for local_def_id in &keys {
             self.refine_fn_def(*local_def_id);

--- a/src/analyze/crate_.rs
+++ b/src/analyze/crate_.rs
@@ -60,10 +60,35 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     }
 
     fn refine_local_defs(&mut self) {
+        let mut keys = self.tcx.mir_keys(()).clone();
         for local_def_id in self.tcx.mir_keys(()) {
-            if self.tcx.def_kind(*local_def_id).is_fn_like() {
-                self.refine_fn_def(*local_def_id);
+            let analyzer = self.ctx.local_def_analyzer(*local_def_id);
+            if analyzer.is_annotated_as_extern_spec_fn() {
+                let target_def_id = analyzer.extern_spec_fn_target_def_id();
+                if let Some(local_target_def_id) = target_def_id.as_local() {
+                    keys.swap_remove(&local_target_def_id);
+                }
             }
+            if analyzer.is_annotated_as_ignored() {
+                self.skip_analysis.insert(*local_def_id);
+                keys.swap_remove(local_def_id);
+            }
+            if analyzer.is_annotated_as_predicate() {
+                analyzer.analyze_predicate_definition();
+                self.skip_analysis.insert(*local_def_id);
+                keys.swap_remove(local_def_id);
+            }
+            if analyzer.is_annotated_as_formula_fn() {
+                self.ctx.register_formula_fn(*local_def_id);
+                self.skip_analysis.insert(*local_def_id);
+                keys.swap_remove(local_def_id);
+            }
+            if !self.tcx.def_kind(*local_def_id).is_fn_like() {
+                keys.swap_remove(local_def_id);
+            }
+        }
+        for local_def_id in &keys {
+            self.refine_fn_def(*local_def_id);
         }
     }
 
@@ -81,23 +106,6 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         if analyzer.is_annotated_as_extern_spec_fn() {
             assert!(analyzer.is_fully_annotated());
             self.skip_analysis.insert(local_def_id);
-        }
-
-        if analyzer.is_annotated_as_ignored() {
-            self.skip_analysis.insert(local_def_id);
-            return;
-        }
-
-        if analyzer.is_annotated_as_predicate() {
-            analyzer.analyze_predicate_definition();
-            self.skip_analysis.insert(local_def_id);
-            return;
-        }
-
-        if analyzer.is_annotated_as_formula_fn() {
-            self.ctx.register_formula_fn(local_def_id);
-            self.skip_analysis.insert(local_def_id);
-            return;
         }
 
         // skip analysis if the def is closure defined in skipped def

--- a/tests/ui/fail/partialeq_impl.rs
+++ b/tests/ui/fail/partialeq_impl.rs
@@ -1,0 +1,30 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+enum X {
+    A(i32),
+}
+
+impl thrust_models::Model for X {
+    type Ty = Self;
+}
+
+impl PartialEq for X {
+    fn eq(&self, other: &X) -> bool {
+        match (self, other) {
+            (Self::A(lhs), Self::A(rhs)) => !lhs.eq(rhs),
+        }
+    }
+}
+
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+fn rand() -> X {
+    unimplemented!()
+}
+
+fn main() {
+    let x = rand();
+    assert!(x == x);
+}

--- a/tests/ui/pass/partialeq_impl.rs
+++ b/tests/ui/pass/partialeq_impl.rs
@@ -1,0 +1,30 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+enum X {
+    A(i32),
+}
+
+impl thrust_models::Model for X {
+    type Ty = Self;
+}
+
+impl PartialEq for X {
+    fn eq(&self, other: &X) -> bool {
+        match (self, other) {
+            (Self::A(lhs), Self::A(rhs)) => lhs.eq(rhs),
+        }
+    }
+}
+
+#[thrust::trusted]
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+fn rand() -> X {
+    unimplemented!()
+}
+
+fn main() {
+    let x = rand();
+    assert!(x == x);
+}


### PR DESCRIPTION
## Summary

A hand-written trait-method impl was never checked against the trait method's (extern) spec, so an implementation that contradicts the spec was accepted as safe. For example, this program verified even though the assertion can fail:

```rust
enum A { X(i32) }
impl thrust_models::Model for A { type Ty = Self; }
impl PartialEq for A {
    fn eq(&self, other: &A) -> bool {
        match (self, other) { (Self::X(l), Self::X(r)) => !l.eq(r) } // note the `!`
    }
}
#[thrust::trusted]
#[thrust_macros::requires(true)]
#[thrust_macros::ensures(true)]
fn rand() -> A { unimplemented!() }
fn main() { let x = rand(); assert!(x == x); }
```

`x == x` lowers to `<A as PartialEq>::eq`, which Thrust models with the blanket extern spec `result == (*x == *y)` (structural equality). The impl above returns the negation, so `x == x` is really `false` and the assertion can fail — yet Thrust reported the program safe.

## Root cause

A trait-impl method without its own annotation is meant to be checked against the trait method's spec, which `expected_ty` obtains via `trait_item_ty` → `def_ty_with_args` on the trait method def. That lookup returns `None` unless the trait method's (extern) spec is already registered. Because `refine_local_defs` walked `mir_keys` in a single pass, a user `impl PartialEq for A` (low `DefId`) was refined before the blanket `PartialEq::eq` extern spec injected by `std.rs` (high `DefId`), so the impl fell back to an unconstrained template and its body was never checked against the spec.

The pass also double-registered keys in an order-dependent way: a trait method and its extern-spec companion both register the same `defs` entry, and correctness relied on the companion being inserted last.

## Changes

- **Stop `register_def` of the target of an `extern_spec_fn`.** The plain target is dropped from the refine set so only the extern spec registers that key, removing the order-dependent double-registration. The `ignored` / `predicate` / `formula_fn` classification is done in the same pre-scan, so a trusted/ignored target still lands in `skip_analysis` and its body is not analyzed.
- **Prioritize trait-method spec keys.** Refine formula functions and trait-method (`AssocFn`) extern specs before ordinary defs, so a trait method's spec is registered before trait-impl methods consult it via `trait_item_ty`, independent of `mir_keys` iteration order.

## Tests

- `tests/ui/fail/partialeq_impl.rs` — a `PartialEq` impl that negates structural equality is now rejected (`Unsat`).
- `tests/ui/pass/partialeq_impl.rs` — a `PartialEq` impl consistent with structural equality still verifies.

The full `ui` suite passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VowL2RdawM4Xch4tsdbSf3)_