### PR TITLE
Keep the removed parameter's refinement in remove_param

### DIFF
--- a/src/rty.rs
+++ b/src/rty.rs
@@ -303,6 +303,18 @@ impl FunctionType {
             Box::new(RefinedType::unrefined(Type::unit())),
         );
         self.ret = Box::new(old_ret.map_var(shift));
+
+        if let Some(last_idx) = self.params.last_index() {
+            let refinement = removed.refinement.clone().map_var(|v| match v {
+                RefinedTypeVar::Value => {
+                    panic!("refinement of the parameter being removed references its own value")
+                }
+                RefinedTypeVar::Free(v) if shift(v) == last_idx => RefinedTypeVar::Value,
+                RefinedTypeVar::Free(v) => RefinedTypeVar::Free(shift(v)),
+                v => v,
+            });
+            self.params[last_idx].refinement.push_conj(refinement);
+        }
         removed
     }
 

--- a/tests/ui/fail/closure_no_capture_fn_param.rs
+++ b/tests/ui/fail/closure_no_capture_fn_param.rs
@@ -1,0 +1,12 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust::callable]
+fn check(v: i32) {
+    let incr = |x| {
+        x + 1
+    };
+    assert!(incr(v) == v);
+}
+
+fn main() {}

--- a/tests/ui/pass/closure_no_capture_fn_param.rs
+++ b/tests/ui/pass/closure_no_capture_fn_param.rs
@@ -1,0 +1,12 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+#[thrust::callable]
+fn check(v: i32) {
+    let incr = |x| {
+        x + 1
+    };
+    assert!(incr(v) == v + 1);
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #197.

## Root cause

A function type keeps its precondition on the **last** parameter (`BasicBlockType::set_precondition`, `truncate_outer_fn_params`), but `remove_param` dropped the refinement of the parameter it removed.

The entry basic block type orders its local parameters by `Local` index, so they run `_0` (`RETURN_PLACE`), then the arguments, then any temporary that liveness reports as live at entry — which happens for ZST locals such as a non-capturing closure or a unit struct. `drop_bb_zst_params` removes every parameter whose local is not a function argument, so when the last local is such a temporary, the precondition went with it and `assert_entry` never emitted a clause with that predicate variable in a head. The predicate then occurred only in clause bodies, so the solver satisfied the system by reading it as the empty relation, and every obligation after that point was discharged vacuously — a program that always panics verified as `safe`.

Only the `arg_count == 0` case survived, because `drop_bb_zst_params` re-introduces a synthetic unit parameter carrying the refinement of the last dropped parameter.

Before, for `fn check(v: i32) { let f = |a: i32| a; f(v); assert!(1 == 2); }`:

```
assert_entry before entry=(_0: (), _1: int, _2: (), { int | p4 ν $1 }) → ()
assert_entry after  entry=(int) → ()
```

`p4` is gone, and the emitted CHC system contains no clause with `p4` in a head.

## Trigger

The trigger is broader than the issue describes: any function with at least one argument whose entry block has a live non-argument ZST local. Neither an argument at the call site nor a closure at all is required — `fn check(v: i32) { let z = Z; take(&z); assert!(1 == 2); }` for a unit struct `Z` verifies as `safe` too.

## Change

`remove_param` now conjoins the removed parameter's refinement to the last remaining parameter, rebinding the reference to that parameter as the value variable. Removal no longer weakens the precondition, and callers do not have to know where a function type keeps it.

## Testing

- `tests/ui/{pass,fail}/closure_no_capture_fn_param.rs` added. The `fail` one is rejected without this change and passes with it.
- The reproducers from the issue, the no-argument closure variant, a two-argument variant, the closure-free unit-struct variant, and the parameterless variants all report `Unsat` now; `assert!(f(v) == v)` still verifies as `safe`.
- `cargo test`, `cargo fmt --check`, `cargo clippy -- -D warnings`. The test run has 32 pre-existing failures in this environment because PCSat (`tests/thrust-pcsat-wrapper`) is unavailable; the failing set is identical with and without this change.