### PR TITLE
Bump the Z3 pinned for CI to 5.0.0

### DIFF
--- a/.github/actions/setup-z3/action.yml
+++ b/.github/actions/setup-z3/action.yml
@@ -4,17 +4,17 @@ inputs:
   z3-version:
     description: The version of Z3 to install.
     required: false
-    default: 4.15.4
+    default: 5.0.0
   z3-variant:
-    description: The variant of Z3 to install (includes arch, e.g. x64-glibc-2.39, arm64-glibc-2.34).
+    description: The variant of Z3 to install (includes arch, e.g. x64-glibc-2.39, arm64-glibc-2.38).
     required: false
     default: x64-glibc-2.39
   z3-sha256sum:
     description: Expected sha256sum of downloaded binary archive.
     required: false
     default: |
-      a41b690e89c343931471506cdc6d957b6044a200fd2d240cc017432afdff7d3e  z3-4.15.4-x64-glibc-2.39.zip
-      9e832578e28d9ed51a79b97948728a874854a3c38ee49e7aae05e7d6e0e93508  z3-4.15.4-arm64-glibc-2.34.zip
+      d4922cebc9f0a55629231ec0c62f0bbedf8006eddaed4e68199ad19626b697f6  z3-5.0.0-x64-glibc-2.39.zip
+      c9437ff7e419e715db76d20e4b2142bf60a206c8e1d2b380c0ce35dc8d07b1f4  z3-5.0.0-arm64-glibc-2.38.zip
 runs:
   using: composite
   steps:


### PR DESCRIPTION
Moves `.github/actions/setup-z3` from Z3 4.15.4 to 5.0.0.

The arm64 release archive is named after glibc 2.38 as of this version (`z3-5.0.0-arm64-glibc-2.38.zip`, previously `arm64-glibc-2.34`), so the variant naming in the `z3-variant` description and in the checksum list changes along with the version. The x64 variant name is unchanged, so `ci.yml` needs no update — it takes the defaults. Both checksums were verified against the archives downloaded from the release.

## Compatibility

Verified against the test suite before making the change:

- **Verification results are unchanged.** All 276 UI tests that go through Z3 (the rest use `tests/thrust-pcsat-wrapper`, which never invokes Z3) produce the same outcome under both versions, and `cargo test` reaches the same set of passing tests under each.
- **The solver arguments are still accepted.** `fp.spacer.global` and `fp.validate` both remain; the diff of `z3 -pm:fp` between the two versions is limited to help-text formatting and a newly added `fp.rlimit`.
- **Solving time is essentially unchanged**, 79.5s to 80.9s in total across those 276 tests, with no test anywhere near its `THRUST_SOLVER_TIMEOUT_SECS`.
- **The glibc requirement is unchanged.** Both binaries reference symbols up to `GLIBC_2.38`.

One caveat on the evidence: every UI test finishes in under 1.5s, so the suite does not exercise Spacer heavily. This shows the existing tests behave identically, not that convergence is unchanged on harder inputs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENP6gXrPMMyXEY8PBQHVgW)_