### PR TITLE
Bind the structure of the value a mutable borrow prophesies

### DIFF
--- a/src/refine/env.rs
+++ b/src/refine/env.rs
@@ -1001,16 +1001,38 @@ where
         self.var_type(local.into())
     }
 
+    /// Returns the variable holding the value of `current` after a mutable borrow of it ends,
+    /// which the borrow's `prophecy` variable stands for.
+    ///
+    /// When `current` has a flow binding, the prophesied value is given one as well, so that it
+    /// can be projected and borrowed through just like the value it replaces. `prophecy` itself
+    /// is an opaque variable and admits neither, which would leave a reference stored in the
+    /// prophesied value unusable as the target of a later write.
+    fn bind_prophesied_value(&mut self, current: TempVarIdx, prophecy: TempVarIdx) -> TempVarIdx {
+        if self.flow_binding(current.into()).is_none() {
+            return prophecy;
+        }
+        let ty = self.var_type(current.into()).ty;
+        let refinement = chc::Term::var(rty::RefinedTypeVar::Value)
+            .equal_to(chc::Term::var(rty::RefinedTypeVar::Free(prophecy.into())))
+            .into();
+        let var = self.temp_vars.next_index();
+        self.bind_impl(var.into(), rty::RefinedType::new(ty, refinement), 0);
+        var
+    }
+
     fn borrow_var(&mut self, var: Var, prophecy: TempVarIdx) -> PlaceType {
         match *self.flow_binding(var).expect("borrowing unbound var") {
             FlowBinding::Box(x) => {
                 let inner_ty = self.var_type(x.into());
-                self.insert_flow_binding(var, FlowBinding::Box(prophecy));
+                let current = self.bind_prophesied_value(x, prophecy);
+                self.insert_flow_binding(var, FlowBinding::Box(current));
                 inner_ty.mut_with_proph_term(chc::Term::var(prophecy.into()))
             }
             FlowBinding::Mut(x1, x2) => {
                 let inner_ty = self.var_type(x1.into());
-                self.insert_flow_binding(var, FlowBinding::Mut(prophecy, x2));
+                let current = self.bind_prophesied_value(x1, prophecy);
+                self.insert_flow_binding(var, FlowBinding::Mut(current, x2));
                 inner_ty.mut_with_proph_term(chc::Term::var(prophecy.into()))
             }
             _ => panic!("invalid borrow"),

--- a/tests/ui/fail/reassign_mut_ref.rs
+++ b/tests/ui/fail/reassign_mut_ref.rs
@@ -1,0 +1,12 @@
+//@error-in-other-file: Unsat
+
+fn main() {
+    let mut a = 1_i64;
+    let mut b = 2_i64;
+    let mut r = &mut a;
+    *r = 10;
+    r = &mut b;
+    *r = 20;
+    assert!(a == 10);
+    assert!(b == 21);
+}

--- a/tests/ui/pass/reassign_mut_ref.rs
+++ b/tests/ui/pass/reassign_mut_ref.rs
@@ -1,0 +1,12 @@
+//@check-pass
+
+fn main() {
+    let mut a = 1_i64;
+    let mut b = 2_i64;
+    let mut r = &mut a;
+    *r = 10;
+    r = &mut b;
+    *r = 20;
+    assert!(a == 10);
+    assert!(b == 20);
+}


### PR DESCRIPTION
Fixes #176.

## Cause

`Env::borrow_var` rebinds the borrowed variable to the borrow's prophecy variable, which stands for the value the place takes once the borrow ends. That variable comes from `push_temp_var`, so it is bound as a value (`TempVarBinding::Type`), not with the `FlowBinding` that `locate_place` and `borrow_var` walk to reach through a reference, a box, a tuple, or an enum. A place whose value has structure therefore lost that structure as soon as it was borrowed.

Writing to a `mut` local is elaborated into a borrow of the local's slot (`ReborrowVisitor::visit_assign`), which is why the issue's straight-line reassignment hit exactly that: `r = &mut b` left `r`'s content standing for the prophecy, and elaborating `*r = 20` into a reborrow of `*r` reached `borrow_var` with no binding — `borrowing unbound var`. The same reassignment of a tuple local panics with `deref unbound var` when a field is projected afterwards. Reading through the reassigned local was fine, since reads go through `place_type`, which needs no flow binding; and the cross-basic-block form was fine too, since a block entry re-binds its locals from the block type.

## Fix

`bind_prophesied_value` binds a fresh variable refined to equal the prophecy through `bind_impl`, so the prophesied value carries the structure of the value it replaces. A value that had no flow binding to begin with keeps standing for the prophecy variable directly, so the constraints generated for a borrow of a scalar are unchanged.

## Tests

`tests/ui/{pass,fail}/reassign_mut_ref.rs` write through a `&mut` local both before and after reassigning it, and check both referents afterwards; the failing side breaks the assertion on the reassigned referent.

Also checked by hand, all verifying as expected after the fix and all but the last panicking before it:

| Program | Before | After |
| --- | --- | --- |
| `r = &mut b; *r = 20; assert!(b == 20)` | `borrowing unbound var` | passes |
| `r = &mut b; *r = 20; assert!(b == 21)` | `borrowing unbound var` | `Unsat` |
| `r = &mut b; *r = 20; assert!(a == 20)` | `borrowing unbound var` | `Unsat` |
| `r = &mut a; *r = 5; assert!(a == 5)` (same referent) | `borrowing unbound var` | passes |
| `t = (3, 4); t.0 = 5; assert!(t.0 == 5 && t.1 == 4)` | `deref unbound var` | passes |
| `x = Box::new(2); *x = 3; assert!(*x == 3)` | passes | passes |

---
_Generated by [Claude Code](https://claude.ai/code/session_017gbkD8SESxdRSj7taHpFJs)_