### PR TITLE
Skip non-fn-like defs before constructing their analyzer

### DIFF
--- a/src/analyze/crate_.rs
+++ b/src/analyze/crate_.rs
@@ -65,6 +65,10 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         let mut keys = self.tcx.mir_keys(()).clone();
         let mut trait_method_spec_keys = HashSet::new();
         for local_def_id in self.tcx.mir_keys(()) {
+            if !self.tcx.def_kind(*local_def_id).is_fn_like() {
+                keys.swap_remove(local_def_id);
+                continue;
+            }
             let analyzer = self.ctx.local_def_analyzer(*local_def_id);
             if analyzer.is_annotated_as_extern_spec_fn() {
                 let target_def_id = analyzer.extern_spec_fn_target_def_id();
@@ -91,9 +95,6 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             if analyzer.is_annotated_as_formula_fn() {
                 self.ctx.register_formula_fn(*local_def_id);
                 self.skip_analysis.insert(*local_def_id);
-                keys.swap_remove(local_def_id);
-            }
-            if !self.tcx.def_kind(*local_def_id).is_fn_like() {
                 keys.swap_remove(local_def_id);
             }
         }


### PR DESCRIPTION
`refine_local_defs` built a `local_def::Analyzer` for every `mir_keys` entry and only dropped the non-fn-like ones at the end of the loop body. `Analyzer::new` fetches `optimized_mir`, which rustc forbids for `const`/`static` items, so a crate containing any such item aborted the compiler before verification started.

This moves the `is_fn_like` guard ahead of the `local_def_analyzer` call, matching what `analyze_local_defs` already does.

Checked against the reproductions in #198:

- `const K: i64 = 42; fn main() {}` — now verifies
- `const K: i64 = 42; fn main() { let x = K; assert!(x == 42); }` — now verifies
- `static S: i64 = 7; ...` — no longer aborts the compiler; reaches `unimplemented!("const ptr alloc: Static(..)")` in `const_value_ty`
- `let a = [0i64; 3];` — no longer aborts the compiler; reaches `unimplemented!("rvalue=[const 0_i64; 3]")` in `rvalue_type`

The latter two are ordinary unsupported-construct panics, out of scope here.

No test cases added, per request.

Fixes #198

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkS7GoCBGCCyj562jZQm7E)_