### PR TITLE
Bridge the rust-call receiver in pre!/post!

### DIFF
--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -416,33 +416,37 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
         }
     }
 
-    /// Whether the receiver denotes the mutable-reference model of a closure (`&mut F` in the
-    /// specified signature) rather than the closure itself.
-    fn is_mut_receiver(&self, ty: mir_ty::Ty<'tcx>) -> bool {
-        matches!(
-            ty.kind(),
-            mir_ty::TyKind::Adt(adt, _) if Some(adt.did()) == self.def_ids.mut_model()
-        )
-    }
-
-    /// The receiver term to supply as the closure's upvars, which are the first parameter of its
-    /// [`rty::FunctionType`].
+    /// The receiver term as the closure's own body takes it.
     ///
-    /// A closure that mutates its upvars receives them behind a `Mut` holding the upvars on entry
-    /// and on exit, while a specification names the closure either by value or through a `&mut`,
-    /// so the two shapes need not agree. A closure value stands for upvars that the call leaves
-    /// as they are, and a `&mut` to a closure contributes the upvars it holds on entry.
+    /// That body takes the upvars by `&`, by `&mut`, or by value, following the kind inferred
+    /// for the closure, while `pre!`/`post!` reach the closure through the parameter the
+    /// annotated function declares. A call bridges the two by borrowing the closure into the
+    /// receiver the body takes; the same borrow is taken here on the term.
     fn closure_receiver_term(
         &self,
         receiver: &'tcx rustc_hir::Expr<'tcx>,
         fn_ty: &rty::FunctionType,
     ) -> chc::Term<rty::FunctionParamIdx> {
+        let held_as = match self.expr_ty(receiver).kind() {
+            mir_ty::TyKind::Adt(adt, _) if Some(adt.did()) == self.def_ids.mut_model() => {
+                Some(rty::RefKind::Mut)
+            }
+            mir_ty::TyKind::Ref(_, _, mir_ty::Mutability::Not) => Some(rty::RefKind::Immut),
+            _ => None,
+        };
         let upvars_ty = &fn_ty.params[rty::FunctionParamIdx::from(0usize)].ty;
-        let receiver_is_mut = self.is_mut_receiver(self.expr_ty(receiver));
+        let received_as = match upvars_ty.as_pointer().map(|ty| ty.kind) {
+            Some(rty::PointerKind::Ref(kind)) => Some(kind),
+            _ => None,
+        };
+
         let term = self.to_term(receiver);
-        match (upvars_ty.is_mut(), receiver_is_mut) {
-            (true, false) => chc::Term::mut_(term.clone(), term),
-            (false, true) => term.mut_current(),
+        match (held_as, received_as) {
+            (None, Some(rty::RefKind::Immut)) => chc::Term::box_(term),
+            (None, Some(rty::RefKind::Mut)) => chc::Term::mut_(term.clone(), term),
+            (Some(rty::RefKind::Mut), Some(rty::RefKind::Immut)) => {
+                chc::Term::box_(term.mut_current())
+            }
             _ => term,
         }
     }

--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -425,23 +425,22 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
         )
     }
 
-    /// The receiver term to supply as the closure's environment, which is the first parameter of
-    /// its contract.
+    /// The receiver term to supply as the closure's upvars, which are the first parameter of its
+    /// [`rty::FunctionType`].
     ///
-    /// A closure that mutates its environment receives it behind a `Mut` holding the environment
-    /// on entry and on exit, while a specification names the closure either by value or through a
-    /// `&mut`, so the two shapes need not agree. A closure value stands for an environment that
-    /// the call leaves as it is, and a `&mut` to a closure contributes the environment it holds on
-    /// entry.
+    /// A closure that mutates its upvars receives them behind a `Mut` holding the upvars on entry
+    /// and on exit, while a specification names the closure either by value or through a `&mut`,
+    /// so the two shapes need not agree. A closure value stands for upvars that the call leaves
+    /// as they are, and a `&mut` to a closure contributes the upvars it holds on entry.
     fn closure_receiver_term(
         &self,
         receiver: &'tcx rustc_hir::Expr<'tcx>,
         fn_ty: &rty::FunctionType,
     ) -> chc::Term<rty::FunctionParamIdx> {
-        let env_ty = &fn_ty.params[rty::FunctionParamIdx::from(0usize)].ty;
+        let upvars_ty = &fn_ty.params[rty::FunctionParamIdx::from(0usize)].ty;
         let receiver_is_mut = self.is_mut_receiver(self.expr_ty(receiver));
         let term = self.to_term(receiver);
-        match (env_ty.is_mut(), receiver_is_mut) {
+        match (upvars_ty.is_mut(), receiver_is_mut) {
             (true, false) => chc::Term::mut_(term.clone(), term),
             (false, true) => term.mut_current(),
             _ => term,

--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -416,6 +416,38 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
         }
     }
 
+    /// Whether the receiver denotes the mutable-reference model of a closure (`&mut F` in the
+    /// specified signature) rather than the closure itself.
+    fn is_mut_receiver(&self, ty: mir_ty::Ty<'tcx>) -> bool {
+        matches!(
+            ty.kind(),
+            mir_ty::TyKind::Adt(adt, _) if Some(adt.did()) == self.def_ids.mut_model()
+        )
+    }
+
+    /// The receiver term to supply as the closure's environment, which is the first parameter of
+    /// its contract.
+    ///
+    /// A closure that mutates its environment receives it behind a `Mut` holding the environment
+    /// on entry and on exit, while a specification names the closure either by value or through a
+    /// `&mut`, so the two shapes need not agree. A closure value stands for an environment that
+    /// the call leaves as it is, and a `&mut` to a closure contributes the environment it holds on
+    /// entry.
+    fn closure_receiver_term(
+        &self,
+        receiver: &'tcx rustc_hir::Expr<'tcx>,
+        fn_ty: &rty::FunctionType,
+    ) -> chc::Term<rty::FunctionParamIdx> {
+        let env_ty = &fn_ty.params[rty::FunctionParamIdx::from(0usize)].ty;
+        let receiver_is_mut = self.is_mut_receiver(self.expr_ty(receiver));
+        let term = self.to_term(receiver);
+        match (env_ty.is_mut(), receiver_is_mut) {
+            (true, false) => chc::Term::mut_(term.clone(), term),
+            (false, true) => term.mut_current(),
+            _ => term,
+        }
+    }
+
     /// Resolves the [`rty::FunctionType`] of the closure contract referred to by the receiver.
     ///
     /// The receiver type is instantiated to the actual closure type in the formula function; its
@@ -467,7 +499,7 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
             "closure precondition arity mismatch: closure takes {} argument(s)",
             fn_ty.params.len() - 1
         );
-        let param_args: Vec<_> = std::iter::once(self.to_term(receiver))
+        let param_args: Vec<_> = std::iter::once(self.closure_receiver_term(receiver, &fn_ty))
             .chain(logical_args)
             .collect();
         FormulaOrTerm::Formula(fn_ty.precondition_formula(&param_args))
@@ -497,7 +529,7 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
             "closure postcondition arity mismatch: closure takes {} argument(s)",
             fn_ty.params.len() - 1
         );
-        let param_args: Vec<_> = std::iter::once(self.to_term(receiver))
+        let param_args: Vec<_> = std::iter::once(self.closure_receiver_term(receiver, &fn_ty))
             .chain(logical_args)
             .collect();
         let result = self.to_term(result);

--- a/tests/ui/fail/closure_mut_capture_pre_post.rs
+++ b/tests/ui/fail/closure_mut_capture_pre_post.rs
@@ -1,0 +1,19 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(thrust_macros::pre!(f()))]
+#[thrust_macros::ensures(thrust_macros::post!(f(), result))]
+fn call<F: FnMut() -> i64>(mut f: F) -> i64 {
+    f()
+}
+
+fn main() {
+    let mut cnt: i64 = 0;
+    let f = || -> i64 {
+        cnt += 1;
+        cnt
+    };
+    let r = call(f);
+    // `f` increments `cnt` once, so `r == 1`
+    assert!(r == 2);
+}

--- a/tests/ui/fail/closure_receiver_mut_model_byval.rs
+++ b/tests/ui/fail/closure_receiver_mut_model_byval.rs
@@ -1,0 +1,28 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::{
+    exists,
+    model::{Int, Mut},
+};
+
+#[thrust_macros::ensures(exists(|g, h, i: Int|
+  thrust_macros::post!(Mut::new(f, g)(), i)
+  && thrust_macros::post!(Mut::new(g, h)(), result)
+))]
+fn call_twice<F: FnMut() -> i64>(mut f: F) -> i64 {
+    f();
+    f()
+}
+
+fn main() {
+    let mut cnt: i64 = 0;
+    let f = move || -> i64 {
+        cnt += 1;
+        cnt
+    };
+    let r = call_twice(f);
+    // `f` increments `cnt` on each of the two calls, so `r == 2`
+    assert!(r == 3);
+}

--- a/tests/ui/fail/closure_ref_mut_pre_post.rs
+++ b/tests/ui/fail/closure_ref_mut_pre_post.rs
@@ -1,0 +1,16 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(thrust_macros::pre!(f()))]
+#[thrust_macros::ensures(thrust_macros::post!(f(), result))]
+fn call<F: Fn() -> i64>(f: &mut F) -> i64 {
+    f()
+}
+
+fn main() {
+    let k: i64 = 1;
+    let mut f = || -> i64 { k };
+    let r = call(&mut f);
+    // `f` returns `k`, which is 1
+    assert!(r == 2);
+}

--- a/tests/ui/pass/closure_captures_fn_once.rs
+++ b/tests/ui/pass/closure_captures_fn_once.rs
@@ -2,8 +2,7 @@
 //@compile-flags: -C debug-assertions=off
 
 // Passed straight to `apply` to keep the closure `FnOnce`: binding it to a `let` first
-// makes it `FnMut`, and `pre!`/`post!` hand a `FnMut` closure upvars stripped of their
-// `Mut`.
+// makes it `FnMut`, whose contract holds the captures behind another `Mut`.
 #[thrust_macros::requires(thrust_macros::pre!(f(x)))]
 #[thrust_macros::ensures(thrust_macros::post!(f(x), result))]
 fn apply<F: FnOnce(i32) -> i32>(x: i32, f: F) -> i32 {

--- a/tests/ui/pass/closure_captures_fn_once.rs
+++ b/tests/ui/pass/closure_captures_fn_once.rs
@@ -2,7 +2,7 @@
 //@compile-flags: -C debug-assertions=off
 
 // Passed straight to `apply` to keep the closure `FnOnce`: binding it to a `let` first
-// makes it `FnMut`, whose contract holds the captures behind another `Mut`.
+// makes it `FnMut`, which holds its upvars behind another `Mut`.
 #[thrust_macros::requires(thrust_macros::pre!(f(x)))]
 #[thrust_macros::ensures(thrust_macros::post!(f(x), result))]
 fn apply<F: FnOnce(i32) -> i32>(x: i32, f: F) -> i32 {

--- a/tests/ui/pass/closure_mut_capture_pre_post.rs
+++ b/tests/ui/pass/closure_mut_capture_pre_post.rs
@@ -1,7 +1,7 @@
 //@check-pass
 //@compile-flags: -C debug-assertions=off
 
-// A closure that mutates a capture receives its environment behind a `Mut`, while the
+// A closure that mutates a capture receives its upvars behind a `Mut`, while the
 // higher-order function names the closure by value in `pre!`/`post!`.
 #[thrust_macros::requires(thrust_macros::pre!(f()))]
 #[thrust_macros::ensures(thrust_macros::post!(f(), result))]

--- a/tests/ui/pass/closure_mut_capture_pre_post.rs
+++ b/tests/ui/pass/closure_mut_capture_pre_post.rs
@@ -1,0 +1,20 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+// A closure that mutates a capture receives its environment behind a `Mut`, while the
+// higher-order function names the closure by value in `pre!`/`post!`.
+#[thrust_macros::requires(thrust_macros::pre!(f()))]
+#[thrust_macros::ensures(thrust_macros::post!(f(), result))]
+fn call<F: FnMut() -> i64>(mut f: F) -> i64 {
+    f()
+}
+
+fn main() {
+    let mut cnt: i64 = 0;
+    let f = || -> i64 {
+        cnt += 1;
+        cnt
+    };
+    let r = call(f);
+    assert!(r == 1);
+}

--- a/tests/ui/pass/closure_receiver_mut_model_byval.rs
+++ b/tests/ui/pass/closure_receiver_mut_model_byval.rs
@@ -1,0 +1,30 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::{
+    exists,
+    model::{Int, Mut},
+};
+
+// Naming the closure by value leaves its environment as the call found it, which cannot
+// carry the environment from one call to the next. `Mut::new` builds the receiver instead,
+// naming the environment between the two calls.
+#[thrust_macros::ensures(exists(|g, h, i: Int|
+  thrust_macros::post!(Mut::new(f, g)(), i)
+  && thrust_macros::post!(Mut::new(g, h)(), result)
+))]
+fn call_twice<F: FnMut() -> i64>(mut f: F) -> i64 {
+    f();
+    f()
+}
+
+fn main() {
+    let mut cnt: i64 = 0;
+    let f = move || -> i64 {
+        cnt += 1;
+        cnt
+    };
+    let r = call_twice(f);
+    assert!(r == 2);
+}

--- a/tests/ui/pass/closure_receiver_mut_model_byval.rs
+++ b/tests/ui/pass/closure_receiver_mut_model_byval.rs
@@ -7,9 +7,9 @@ use thrust_models::{
     model::{Int, Mut},
 };
 
-// Naming the closure by value leaves its environment as the call found it, which cannot
-// carry the environment from one call to the next. `Mut::new` builds the receiver instead,
-// naming the environment between the two calls.
+// Naming the closure by value leaves its upvars as the call found them, which cannot carry
+// the upvars from one call to the next. `Mut::new` builds the receiver instead, naming the
+// upvars between the two calls.
 #[thrust_macros::ensures(exists(|g, h, i: Int|
   thrust_macros::post!(Mut::new(f, g)(), i)
   && thrust_macros::post!(Mut::new(g, h)(), result)

--- a/tests/ui/pass/closure_ref_mut_pre_post.rs
+++ b/tests/ui/pass/closure_ref_mut_pre_post.rs
@@ -1,0 +1,17 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+// The higher-order function names the closure through a `&mut` in `pre!`/`post!`, while a
+// closure that only reads its captures receives its environment as it is.
+#[thrust_macros::requires(thrust_macros::pre!(f()))]
+#[thrust_macros::ensures(thrust_macros::post!(f(), result))]
+fn call<F: Fn() -> i64>(f: &mut F) -> i64 {
+    f()
+}
+
+fn main() {
+    let k: i64 = 1;
+    let mut f = || -> i64 { k };
+    let r = call(&mut f);
+    assert!(r == 1);
+}

--- a/tests/ui/pass/closure_ref_mut_pre_post.rs
+++ b/tests/ui/pass/closure_ref_mut_pre_post.rs
@@ -2,7 +2,7 @@
 //@compile-flags: -C debug-assertions=off
 
 // The higher-order function names the closure through a `&mut` in `pre!`/`post!`, while a
-// closure that only reads its captures receives its environment as it is.
+// closure that only reads its captures receives its upvars as they are.
 #[thrust_macros::requires(thrust_macros::pre!(f()))]
 #[thrust_macros::ensures(thrust_macros::post!(f(), result))]
 fn call<F: Fn() -> i64>(f: &mut F) -> i64 {


### PR DESCRIPTION
Fixes #206.

## Problem

A specification holds a closure as its signature says, while the closure body takes it as its rust-call receiver: a closure that mutates its upvars takes them behind a `Mut`, one that only reads them takes them behind a `&`, one that consumes them takes them as they are. `pre!(f(..))` / `post!(f(..), r)` applied the closure's pre- and postcondition to the receiver as the specification names it, so the two could disagree:

- a closure value (`f: F`) against a body taking `&mut {closure}` — the mutating-capture case in #206;
- a `&mut` to a closure (`f: &mut F`) against a body taking `&{closure}`.

Either way the predicate variable was emitted at a sort other than its declaration, and the solver aborted before producing a verdict:

```
unknown constant p2 (A1_Tuple<Mut<Int>>)
declared: (declare-fun p2 (A2_Mut<Tuple<Mut<Int>>>) Bool)
```

## Change

`closure_receiver_term` takes the receiver term through the same three steps `RustCallVisitor` performs on the argument of a call:

- a closure value borrowed as `&{closure}`;
- a closure value borrowed as `&mut {closure}`;
- a `&mut {closure}` reborrowed as `&{closure}`.

A receiver the body already takes as it stands is left alone. In particular a receiver that carries a `Mut` for a body that takes one keeps it, and with it the upvars the call leaves behind — which is what `Mut::new(f, g)` is for.

The mutable borrow of a closure value ends the call holding the upvars it started with. That is as much as a specification naming the closure by value can say about them, and it keeps the system in the Horn fragment, which an existential or a universal over the prophecy would leave. A specification that needs the upvars a call leaves behind names the receiver with `Mut::new(f, g)`, for a closure held by value as much as for one held behind a `&mut`; the added test pins this down.

## Tests

- `closure_mut_capture_pre_post`: the reproduction from #206, a `FnMut` closure mutating a capture through a by-value HOF.
- `closure_ref_mut_pre_post`: the other mismatch, a `Fn` closure named through `&mut F`.
- `closure_receiver_mut_model_byval`: two calls to a `move` closure whose upvars hold the counter, with the upvars between the calls named by `Mut::new`.

`cargo test` is green at 314 UI tests (308 before), as are `cargo fmt --check` and `cargo clippy -D warnings`.

The comment on `closure_captures_fn_once` explaining that `pre!`/`post!` strip a `FnMut` closure's upvars of their `Mut` no longer describes the behaviour, so it is updated to the reason that still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192XpBfrsKiGya1e3t3Cj84