### PR TITLE
Use the singleton value in place of a singleton-sorted variable

### DIFF
--- a/src/refine/env.rs
+++ b/src/refine/env.rs
@@ -992,7 +992,16 @@ where
             }
             None => {
                 let rty = self.var(var).expect("unbound var");
-                PlaceType::with_ty_and_term(rty.ty.clone(), chc::Term::var(var))
+                let sort = rty.ty.to_sort();
+                // A variable of a singleton sort is not registered as a clause variable (see
+                // `dependencies`), so it must not be referred to by name. Such a sort has exactly
+                // one value, and that value stands for the variable instead.
+                let term = if sort.is_singleton() {
+                    chc::Term::default_for(&sort)
+                } else {
+                    chc::Term::var(var)
+                };
+                PlaceType::with_ty_and_term(rty.ty.clone(), term)
             }
         }
     }

--- a/tests/ui/fail/fn_ptr_tuple_field.rs
+++ b/tests/ui/fail/fn_ptr_tuple_field.rs
@@ -1,0 +1,12 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+fn add1(x: i64) -> i64 {
+    x + 1
+}
+
+fn main() {
+    let p: (fn(i64) -> i64, i64) = (add1, 3);
+    let a = (p.0)(p.1);
+    assert!(a == 3);
+}

--- a/tests/ui/pass/fn_ptr_tuple_field.rs
+++ b/tests/ui/pass/fn_ptr_tuple_field.rs
@@ -1,0 +1,12 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+fn add1(x: i64) -> i64 {
+    x + 1
+}
+
+fn main() {
+    let p: (fn(i64) -> i64, i64) = (add1, 3);
+    let a = (p.0)(p.1);
+    assert!(a == 4);
+}


### PR DESCRIPTION
Fixes #217.

## Problem

`Env::dependencies` withholds a clause variable from a local whose sort is singleton — such a value carries no logical content, and the rest of the codebase assumes the same (`Template::build`, `with_value_var`, and `From<PlaceType> for RefinedType` all skip singleton sorts the same way).

`Env::var_type`, however, still referred to such a local by name. Storing the local into an aggregate that *also* has a non-singleton field carried that name into the aggregate's term, and the aggregate **does** get a clause variable — so the reference survived into clause construction and aborted there, at either of two consumers:

- `ClauseBuilder::mapped_var` — `unbound var _2`
- `PrecondCapture::finish` — `no entry found for key`

Both `Type::Function` and `Type::String` lower to `chc::Sort::Null`, so a `fn(..)` pointer and a `&str` reproduce it alike; it is the *mixture* of a null-sorted field with a non-singleton one that triggers it, not the function pointer, the call, or the aggregate kind.

## Fix

A singleton sort has exactly one value, so `var_type` names that value (`chc::Term::default_for`) instead of the variable. Nothing dangling reaches clause construction.

## Test

One pass/fail pair, `fn_ptr_tuple_field`: a `(fn(i64) -> i64, i64)` tuple whose `fn` field is called.

This single program covers both panic sites. Verified on the base commit `cd33fbf` by suppressing the `mapped_var` panic — the same program then aborts in `PrecondCapture::finish`, so the call path and the block-boundary path are both exercised. A no-call variant, and a `&str`-instead-of-`fn` variant, were both tried and dropped: each reaches only `PrecondCapture::finish`, a strict subset, and neither can fail independently of this pair.

## Verification

- Every row of the issue's behavior matrix checks safe, including all six previously-panicking rows. Breaking the asserted property in each still yields `Unsat`, so the fix does not paper over the check.
- Full UI suite green, locally and on CI. `fmt`, `clippy`, and `test` all pass.

`tests/ui/fail/option_map.rs` could not be run locally — it reports `verification error: Timeout(30s)` identically at the base commit `cd33fbf` and on this branch, because its pcsat solver runs under Docker in the dev container and cannot find the counterexample within the 30s solver timeout. CI has more headroom and runs it green, confirming it is unrelated to this change.

## Out of scope

- `dependencies` filters singleton *locals* but not singleton *temps*; temps are always registered, which is why that path never hit this asymmetry.
- `Type::Never` also lowers to `Sort::Null` and is presumably covered by the same change, but no case was constructed to confirm it.