### PR TITLE
Pipe the solver's stderr instead of inheriting it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,6 @@ keep from reaching it.
 Neither prerequisite of `cargo test` is set up in the session container. Install Z3 at the
 version `.github/actions/setup-z3` pins for CI, and start a Docker daemon with `dockerd &`.
 The daemon dies from time to time, so restart it whenever the tests that need it fail.
+
+Export the `COAR_IMAGE` digest that `.github/workflows/ci.yml` pins, and `docker pull` it
+before running `cargo test`.

--- a/src/chc/solver.rs
+++ b/src/chc/solver.rs
@@ -75,6 +75,7 @@ impl CommandConfig {
             .args(&self.args)
             .arg(path_arg)
             .stdout(stdout)
+            .stderr(std::process::Stdio::piped())
             .spawn()?;
         tracing::info!(program = self.name, args = ?self.args, path = %path_arg.to_string_lossy(), pid = child.id(), "spawned");
 


### PR DESCRIPTION
`cargo test` sometimes stops making progress locally while CI stays green. The hang is not
in the solver but in the pipe the test harness reads from.

A solver timeout terminates the solver process itself, not anything that process spawned.
`tests/thrust-pcsat-wrapper` spawns `docker run`, and `CommandConfig::run` set only stdout,
leaving stderr inherited — which, under `ui_test`, is the pipe `Command::output()` reads the
whole `thrust-rustc` invocation from. So a timed-out pcsat test leaves the container client
running with a write end of that pipe. `thrust-rustc` exits, the survivor keeps the
descriptor open, the read never reaches EOF, and `ui_test` waits forever. Plain z3 tests are
unaffected: there the timeout kills the only holder of the pipe.

CI does not hit this because it pins `COAR_IMAGE` by digest and pulls it before `cargo test`,
so the pcsat tests finish inside their timeout and nothing is orphaned. A local run without
that falls back to the `:main` tag and pulls the image under the solver timeout, which makes
the timeouts — and the orphans — routine.

Give the solver its own stderr pipe. A survivor then holds a descriptor that dies with
`thrust-rustc` rather than one the test harness waits on. It also fills in the `stderr` of
`CheckSatError::Error`, which was always empty while the solver wrote straight to the
inherited descriptor.

The second commit records the image pull in `CLAUDE.md`, next to the Z3 and `dockerd` setup
already documented there.

## Verification

Both directions were checked against the real binary, with a stand-in solver that reproduces
the wrapper's shape (a bash script whose grandchild outlives a `SIGKILL` to it) driven through
the same `Command::output()` semantics `ui_test` uses, at a 5s solver timeout:

- before: `thrust-rustc` exits after 5s, the caller is still blocked at 60s
- after: the caller returns in 5.3s

The full suite passes with Z3 5.0.0 and the pinned COAR image: 316 ui tests and 2 doc tests,
plus `cargo fmt --check` and `cargo clippy -- -D warnings`.

## Not addressed

This stops the harness from hanging; the orphaned `docker run` and its container still
survive the timeout and keep consuming CPU, which can cascade into further timeouts. Killing
the whole process group, or cleaning up the container from the wrapper via `--cidfile` and a
trap, would be a separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCiKotN28PrBDKAheSAYc)_