### PR TITLE
Register enum defs reachable through ADT fields

### DIFF
--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -1326,27 +1326,40 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     }
 
     fn register_enum_defs(&mut self) {
-        for local_decl in &self.local_decls {
-            use mir_ty::{TypeSuperVisitable as _, TypeVisitable as _};
-            #[derive(Default)]
-            struct EnumCollector {
-                enums: std::collections::HashSet<DefId>,
-            }
-            impl<'tcx> mir_ty::TypeVisitor<mir_ty::TyCtxt<'tcx>> for EnumCollector {
-                fn visit_ty(&mut self, ty: mir_ty::Ty<'tcx>) {
-                    if let mir_ty::TyKind::Adt(adt_def, _) = ty.kind() {
-                        if adt_def.is_enum() {
-                            self.enums.insert(adt_def.did());
+        use mir_ty::{TypeSuperVisitable as _, TypeVisitable as _};
+        struct EnumCollector<'tcx> {
+            tcx: mir_ty::TyCtxt<'tcx>,
+            builder: TypeBuilder<'tcx>,
+            enums: std::collections::HashSet<DefId>,
+            visited: std::collections::HashSet<mir_ty::Ty<'tcx>>,
+        }
+        impl<'tcx> mir_ty::TypeVisitor<mir_ty::TyCtxt<'tcx>> for EnumCollector<'tcx> {
+            fn visit_ty(&mut self, ty: mir_ty::Ty<'tcx>) {
+                let ty = self.builder.resolve_model_ty(ty);
+                if let mir_ty::TyKind::Adt(def, args) = ty.kind() {
+                    if self.visited.insert(ty) {
+                        if def.is_enum() {
+                            self.enums.insert(def.did());
+                        }
+                        for field in def.all_fields() {
+                            field.ty(self.tcx, args).visit_with(self);
                         }
                     }
-                    ty.super_visit_with(self);
                 }
+                ty.super_visit_with(self);
             }
-            let mut visitor = EnumCollector::default();
+        }
+        let mut visitor = EnumCollector {
+            tcx: self.tcx,
+            builder: self.type_builder.clone(),
+            enums: std::collections::HashSet::new(),
+            visited: std::collections::HashSet::new(),
+        };
+        for local_decl in &self.local_decls {
             local_decl.ty.visit_with(&mut visitor);
-            for def_id in visitor.enums {
-                self.ctx.get_or_register_enum_def(def_id);
-            }
+        }
+        for def_id in visitor.enums {
+            self.ctx.get_or_register_enum_def(def_id);
         }
     }
 }

--- a/src/chc.rs
+++ b/src/chc.rs
@@ -1959,6 +1959,12 @@ pub struct Datatype {
     pub ctors: Vec<DatatypeCtor>,
 }
 
+impl Datatype {
+    pub fn selectors(&self) -> impl Iterator<Item = &DatatypeSelector> {
+        self.ctors.iter().flat_map(|ctor| ctor.selectors.iter())
+    }
+}
+
 rustc_index::newtype_index! {
     /// An index of [`Clause`].
     ///

--- a/src/chc/format_context.rs
+++ b/src/chc/format_context.rs
@@ -228,6 +228,12 @@ fn collect_sorts(system: &chc::System) -> BTreeSet<chc::Sort> {
         }
     }
 
+    for sort in sorts.clone() {
+        sort.walk(|inner_sort| {
+            sorts.insert(inner_sort.clone());
+        });
+    }
+
     sorts
 }
 
@@ -269,13 +275,33 @@ fn monomorphize_datatype(
 
 impl FormatContext {
     pub fn from_system(system: &chc::System) -> Self {
-        let mut sorts = collect_sorts(system);
         let mut datatypes = system.datatypes.clone();
-        for sort in sorts.iter().flat_map(|s| s.as_datatype()) {
-            if let Some(mono_datatype) = monomorphize_datatype(sort, &datatypes) {
-                datatypes.push(mono_datatype);
+        let mut sorts = collect_sorts(system);
+
+        let mut pending: Vec<_> = sorts.clone().into_iter().collect();
+        while let Some(sort) = pending.pop() {
+            if let Some(datatype_sort) = sort.as_datatype() {
+                let datatype = match monomorphize_datatype(datatype_sort, &datatypes) {
+                    Some(mono_datatype) => {
+                        datatypes.push(mono_datatype.clone());
+                        mono_datatype
+                    }
+                    None => datatypes
+                        .iter()
+                        .find(|d| d.symbol == datatype_sort.symbol)
+                        .unwrap()
+                        .clone(),
+                };
+                for selector in datatype.selectors() {
+                    selector.sort.walk(|sort| {
+                        if sorts.insert(sort.clone()) {
+                            pending.push(sort.clone());
+                        }
+                    });
+                }
             }
         }
+
         let int_array_elem_sorts: BTreeSet<_> = sorts
             .iter()
             .filter_map(|s| match s {

--- a/src/refine/template.rs
+++ b/src/refine/template.rs
@@ -151,7 +151,7 @@ impl<'tcx> TypeBuilder<'tcx> {
         })
     }
 
-    fn resolve_model_ty(&self, orig_ty: mir_ty::Ty<'tcx>) -> mir_ty::Ty<'tcx> {
+    pub fn resolve_model_ty(&self, orig_ty: mir_ty::Ty<'tcx>) -> mir_ty::Ty<'tcx> {
         let ty = self.replace_closure_model(orig_ty);
 
         let Some(model_ty_def_id) = self.def_ids.model_ty() else {

--- a/tests/ui/fail/adt_enum_field.rs
+++ b/tests/ui/fail/adt_enum_field.rs
@@ -1,0 +1,21 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -Adead_code -C debug-assertions=off
+
+struct Wrap {
+    o: Option<i32>,
+    n: i32,
+}
+
+fn get_n(w: Wrap) -> i32 {
+    w.n
+}
+
+// No local here has a type mentioning `Option`: the enum is reachable only as a
+// field type of `Wrap`, and only the drop of `w` in `get_n` needs its definition.
+#[thrust::callable]
+fn check(w: Wrap) {
+    let n = w.n;
+    assert!(get_n(w) == n + 1);
+}
+
+fn main() {}

--- a/tests/ui/pass/adt_enum_field.rs
+++ b/tests/ui/pass/adt_enum_field.rs
@@ -1,0 +1,21 @@
+//@check-pass
+//@compile-flags: -Adead_code -C debug-assertions=off
+
+struct Wrap {
+    o: Option<i32>,
+    n: i32,
+}
+
+fn get_n(w: Wrap) -> i32 {
+    w.n
+}
+
+// No local here has a type mentioning `Option`: the enum is reachable only as a
+// field type of `Wrap`, and only the drop of `w` in `get_n` needs its definition.
+#[thrust::callable]
+fn check(w: Wrap) {
+    let n = w.n;
+    assert!(get_n(w) == n);
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #221.

## Enum registration

`basic_block::Analyzer::register_enum_defs` discovered the enums a body needs by running a `TypeVisitor` over the types of its local declarations, and `super_visit_with` on an `Adt` descends into that ADT's generic arguments only. An enum occurring solely as the field type of another ADT — `struct Wrap { o: Option<i32> }`, or `enum Outer { X(Inner), Y }` — was therefore never registered, while the elaboration of the outer ADT does reach it, so the `EnumDefProvider` lookup unwrapped a `None`.

The collector now follows the structure the elaboration follows: it resolves the model type first (`TypeBuilder::resolve_model_ty`), and descends into an ADT's field types as well as its generic arguments, with a `visited` set to keep recursive ADTs from looping.

## Undeclared sort

Registering `Option` was not enough to make the by-value reproduction verify: the enum reached `chc::System::datatypes`, but the emitted SMT-LIB2 still referred to `std.option.Option<Int>` without declaring it.

Two gaps in `FormatContext::from_system` caused that. `collect_sorts` collected whole sorts without the sorts they are built from, so the `Option<Int>` inside the tuple `Wrap` elaborates to was never seen; it now closes each collected sort over its components. And a polymorphic datatype was monomorphized in a single pass over the clause sorts, which misses a sort that only appears as another datatype's selector — the pass is now a worklist that pulls in the sorts of the selectors of each datatype it declares.

## Test

`tests/ui/{pass,fail}/adt_enum_field.rs` pins the case. `Wrap` is taken as a parameter and only its `n` field is read, so no local in the file has a type mentioning `Option`: the enum is reachable through the field type alone, and it is the drop of `w` that needs its definition. A body that constructs a `Some` or matches on `w.o` would give some local that type and register the enum along the way — which is what makes the same nesting verify in one program and abort in another. The `fail` file breaks the asserted equality by one.

## Checking

Every program in the issue — both by-value reproductions, the by-reference one, the nested-pattern program, and the two controls — reports `safe`. The new `pass` file aborts at `analyze.rs:215` on the base commit and verifies here; with `struct Wrap { o: Option<i32> }`, a body asserting the wrong field value still reports `Unsat`.

`cargo test` (318 ui tests, unit and doc tests), `cargo clippy -- -D warnings`, and `cargo fmt --check` all pass.