### PR TITLE
Carry what a type states across a basic block boundary

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -585,6 +585,28 @@ impl<'tcx> Analyzer<'tcx> {
         self.basic_blocks.entry(def_id).or_default().insert(bb, def);
     }
 
+    /// Installs the types of a basic block's parameters.
+    ///
+    /// A block whose parameters are typed from MIR types alone carries an unrefined
+    /// specification for every function type they contain. This overwrites those
+    /// parameters with types whose specifications were recovered from elsewhere.
+    pub fn register_basic_block_param_tys(
+        &mut self,
+        def_id: LocalDefId,
+        bb: BasicBlock,
+        tys: impl IntoIterator<Item = (rty::FunctionParamIdx, rty::Type<rty::FunctionParamIdx>)>,
+    ) {
+        let bb_def = self
+            .basic_blocks
+            .get_mut(&def_id)
+            .unwrap()
+            .get_mut(&bb)
+            .unwrap();
+        for (idx, ty) in tys {
+            bb_def.ty.set_param_ty(idx, ty);
+        }
+    }
+
     pub fn register_basic_block_precondition(
         &mut self,
         def_id: LocalDefId,

--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -824,29 +824,32 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             .register_basic_block_precondition(self.local_def_id, bb, precondition);
     }
 
-    /// Rebuilds a goto target's params that contain a function type, taking the
-    /// specifications the env holds.
+    /// Takes the types the env holds for a goto target's params.
     ///
-    /// A function type carries the callee's specification in the type itself rather than
-    /// in a refinement, so a precondition captured from the env cannot bring it along.
-    /// The target's params are typed from their MIR types alone, which leaves every
-    /// function type in them unrefined.
+    /// The captured precondition carries what a parameter's *value* satisfies, and the
+    /// target's params are otherwise built from their MIR types alone. Everything a type
+    /// states by itself is therefore missing from the target: the refinements nested in
+    /// it, and the specification a function type spells out. Those are handed over here.
+    ///
+    /// A type in the env is closed — a refinement nested in one constrains the value at
+    /// its own position and names nothing from the env — so it transfers as it stands.
     fn inherited_param_tys(
         &self,
         bty: &BasicBlockType,
     ) -> Vec<(rty::FunctionParamIdx, rty::Type<rty::FunctionParamIdx>)> {
         let mut tys = Vec::new();
         for (param_idx, param_rty) in bty.as_ref().params.iter_enumerated() {
-            // Only a param standing for a local is ever called; an `OuterFnParam` copy of
-            // a function-typed argument exists to name the argument's entry value.
+            // An `OuterFnParam` copy of an argument names that argument's entry value, and
+            // takes its type from the outer function's signature rather than from the env.
             let BasicBlockTypeParamKind::Local(local, _) = bty.param_kind(param_idx) else {
                 continue;
             };
-            if !param_rty.ty.contains_function() {
-                continue;
-            }
-            let mut ty = param_rty.ty.clone();
-            ty.copy_function_types(&self.env.local_type(local).ty);
+            let ty = self.env.local_type(local).ty.assert_closed().vacuous();
+            assert_eq!(
+                ty.to_sort(),
+                param_rty.ty.to_sort(),
+                "env holds {local:?} at a different sort than the goto target's parameter"
+            );
             tys.push((param_idx, ty));
         }
         tys

--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -816,9 +816,40 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         }
         capture.push_env_state(&self.env);
         let precondition = capture.finish(&self.env);
+        let param_tys = self.inherited_param_tys(bty);
 
         self.ctx
+            .register_basic_block_param_tys(self.local_def_id, bb, param_tys);
+        self.ctx
             .register_basic_block_precondition(self.local_def_id, bb, precondition);
+    }
+
+    /// Rebuilds a goto target's params that contain a function type, taking the
+    /// specifications the env holds.
+    ///
+    /// A function type carries the callee's specification in the type itself rather than
+    /// in a refinement, so a precondition captured from the env cannot bring it along.
+    /// The target's params are typed from their MIR types alone, which leaves every
+    /// function type in them unrefined.
+    fn inherited_param_tys(
+        &self,
+        bty: &BasicBlockType,
+    ) -> Vec<(rty::FunctionParamIdx, rty::Type<rty::FunctionParamIdx>)> {
+        let mut tys = Vec::new();
+        for (param_idx, param_rty) in bty.as_ref().params.iter_enumerated() {
+            // Only a param standing for a local is ever called; an `OuterFnParam` copy of
+            // a function-typed argument exists to name the argument's entry value.
+            let BasicBlockTypeParamKind::Local(local, _) = bty.param_kind(param_idx) else {
+                continue;
+            };
+            if !param_rty.ty.contains_function() {
+                continue;
+            }
+            let mut ty = param_rty.ty.clone();
+            ty.copy_function_types(&self.env.local_type(local).ty);
+            tys.push((param_idx, ty));
+        }
+        tys
     }
 
     fn with_assumptions<F, T>(&mut self, assumptions: Vec<impl Into<Assumption>>, callback: F) -> T

--- a/src/refine/basic_block.rs
+++ b/src/refine/basic_block.rs
@@ -137,6 +137,15 @@ impl BasicBlockType {
         self.ty.clone()
     }
 
+    /// Replaces the type of the parameter at `idx`, keeping its refinement.
+    pub fn set_param_ty(
+        &mut self,
+        idx: rty::FunctionParamIdx,
+        ty: rty::Type<rty::FunctionParamIdx>,
+    ) {
+        self.ty.params[idx].ty = ty;
+    }
+
     pub fn set_precondition(&mut self, refinement: rty::Refinement<rty::FunctionParamIdx>) {
         let last_param_idx = self.ty.params.last_index().unwrap();
         self.ty.params.raw.last_mut().unwrap().refinement = refinement.map_var(|v| {

--- a/src/rty.rs
+++ b/src/rty.rs
@@ -1056,6 +1056,50 @@ impl<T> Type<T> {
         }
     }
 
+    /// Whether a function type occurs anywhere in this type.
+    pub fn contains_function(&self) -> bool {
+        match self {
+            Type::Function(_) => true,
+            Type::Pointer(ty) => ty.elem.ty.contains_function(),
+            Type::Tuple(ty) => ty.elems.iter().any(|elem| elem.ty.contains_function()),
+            Type::Enum(ty) => ty.args.iter().any(|arg| arg.ty.contains_function()),
+            Type::Array(ty) => ty.index.ty.contains_function() || ty.elem.ty.contains_function(),
+            Type::Int | Type::Bool | Type::String | Type::Never | Type::Param(_) => false,
+        }
+    }
+
+    /// Replaces every function type in this type with the one at the same position in `src`.
+    ///
+    /// A function type states the callee's specification in the type itself, so a type built
+    /// from a MIR type alone (see [`crate::refine::TypeBuilder`]) leaves that specification
+    /// unrefined. This takes the specifications from a type of the same shape and leaves the
+    /// rest of this type alone. A position where the two shapes disagree is left as it is:
+    /// missing a specification only costs precision, whereas installing one from an unrelated
+    /// position would be wrong.
+    pub fn copy_function_types<U>(&mut self, src: &Type<U>) {
+        match (self, src) {
+            (Type::Function(dst), Type::Function(src)) => *dst = src.clone(),
+            (Type::Pointer(dst), Type::Pointer(src)) => {
+                dst.elem.ty.copy_function_types(&src.elem.ty)
+            }
+            (Type::Tuple(dst), Type::Tuple(src)) if dst.elems.len() == src.elems.len() => {
+                for (dst, src) in dst.elems.iter_mut().zip(src.elems.iter()) {
+                    dst.ty.copy_function_types(&src.ty);
+                }
+            }
+            (Type::Enum(dst), Type::Enum(src)) if dst.args.len() == src.args.len() => {
+                for (dst, src) in dst.args.iter_mut().zip(src.args.iter()) {
+                    dst.ty.copy_function_types(&src.ty);
+                }
+            }
+            (Type::Array(dst), Type::Array(src)) => {
+                dst.index.ty.copy_function_types(&src.index.ty);
+                dst.elem.ty.copy_function_types(&src.elem.ty);
+            }
+            _ => {}
+        }
+    }
+
     pub fn as_pointer(&self) -> Option<&PointerType<T>> {
         match self {
             Type::Pointer(ty) => Some(ty),

--- a/src/rty.rs
+++ b/src/rty.rs
@@ -1056,50 +1056,6 @@ impl<T> Type<T> {
         }
     }
 
-    /// Whether a function type occurs anywhere in this type.
-    pub fn contains_function(&self) -> bool {
-        match self {
-            Type::Function(_) => true,
-            Type::Pointer(ty) => ty.elem.ty.contains_function(),
-            Type::Tuple(ty) => ty.elems.iter().any(|elem| elem.ty.contains_function()),
-            Type::Enum(ty) => ty.args.iter().any(|arg| arg.ty.contains_function()),
-            Type::Array(ty) => ty.index.ty.contains_function() || ty.elem.ty.contains_function(),
-            Type::Int | Type::Bool | Type::String | Type::Never | Type::Param(_) => false,
-        }
-    }
-
-    /// Replaces every function type in this type with the one at the same position in `src`.
-    ///
-    /// A function type states the callee's specification in the type itself, so a type built
-    /// from a MIR type alone (see [`crate::refine::TypeBuilder`]) leaves that specification
-    /// unrefined. This takes the specifications from a type of the same shape and leaves the
-    /// rest of this type alone. A position where the two shapes disagree is left as it is:
-    /// missing a specification only costs precision, whereas installing one from an unrelated
-    /// position would be wrong.
-    pub fn copy_function_types<U>(&mut self, src: &Type<U>) {
-        match (self, src) {
-            (Type::Function(dst), Type::Function(src)) => *dst = src.clone(),
-            (Type::Pointer(dst), Type::Pointer(src)) => {
-                dst.elem.ty.copy_function_types(&src.elem.ty)
-            }
-            (Type::Tuple(dst), Type::Tuple(src)) if dst.elems.len() == src.elems.len() => {
-                for (dst, src) in dst.elems.iter_mut().zip(src.elems.iter()) {
-                    dst.ty.copy_function_types(&src.ty);
-                }
-            }
-            (Type::Enum(dst), Type::Enum(src)) if dst.args.len() == src.args.len() => {
-                for (dst, src) in dst.args.iter_mut().zip(src.args.iter()) {
-                    dst.ty.copy_function_types(&src.ty);
-                }
-            }
-            (Type::Array(dst), Type::Array(src)) => {
-                dst.index.ty.copy_function_types(&src.index.ty);
-                dst.elem.ty.copy_function_types(&src.elem.ty);
-            }
-            _ => {}
-        }
-    }
-
     pub fn as_pointer(&self) -> Option<&PointerType<T>> {
         match self {
             Type::Pointer(ty) => Some(ty),

--- a/tests/ui/fail/fn_ptr_call_in_branch.rs
+++ b/tests/ui/fail/fn_ptr_call_in_branch.rs
@@ -1,0 +1,18 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+fn add1(x: i64) -> i64 {
+    x + 1
+}
+
+// `add1(0)` is 1 rather than 0.
+#[thrust::callable]
+fn check(c: bool) {
+    let f: fn(i64) -> i64 = add1;
+    if c {
+        let a = f(0);
+        assert!(a == 0);
+    }
+}
+
+fn main() {}

--- a/tests/ui/fail/fn_ptr_call_twice.rs
+++ b/tests/ui/fail/fn_ptr_call_twice.rs
@@ -1,0 +1,15 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+fn incr(m: &mut i64) {
+    *m += 1;
+}
+
+// `x` is incremented twice, so it is 2 rather than 1 here.
+fn main() {
+    let f: fn(&mut i64) = incr;
+    let mut x = 0;
+    f(&mut x);
+    f(&mut x);
+    assert!(x == 1);
+}

--- a/tests/ui/fail/fn_ptr_in_tuple_call_twice.rs
+++ b/tests/ui/fail/fn_ptr_in_tuple_call_twice.rs
@@ -1,0 +1,14 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+fn add1(x: i64) -> i64 {
+    x + 1
+}
+
+// `add1` is applied twice, so the result is 2 rather than 1.
+fn main() {
+    let p: (fn(i64) -> i64,) = (add1,);
+    let a = (p.0)(0);
+    let b = (p.0)(a);
+    assert!(b == 1);
+}

--- a/tests/ui/fail/fn_ptr_param_call_twice.rs
+++ b/tests/ui/fail/fn_ptr_param_call_twice.rs
@@ -1,0 +1,24 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand() -> i64 { unimplemented!() }
+
+fn incr(m: &mut i64) {
+    *m += 1;
+}
+
+fn app(f: fn(&mut i64), mut x: i64) -> i64 {
+    f(&mut x);
+    f(&mut x);
+    x
+}
+
+// `x` is incremented twice, so it is `i + 2` rather than `i + 1` here.
+fn main() {
+    let i = rand();
+    let x = app(incr, i);
+    assert!(x == i + 1);
+}

--- a/tests/ui/pass/fn_ptr_call_in_branch.rs
+++ b/tests/ui/pass/fn_ptr_call_in_branch.rs
@@ -1,0 +1,20 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+fn add1(x: i64) -> i64 {
+    x + 1
+}
+
+// The cast that produces `f` and the call of `f` sit in different basic blocks.
+// The callee's specification must survive that boundary; without it the call's
+// result is unconstrained.
+#[thrust::callable]
+fn check(c: bool) {
+    let f: fn(i64) -> i64 = add1;
+    if c {
+        let a = f(0);
+        assert!(a == 1);
+    }
+}
+
+fn main() {}

--- a/tests/ui/pass/fn_ptr_call_twice.rs
+++ b/tests/ui/pass/fn_ptr_call_twice.rs
@@ -1,0 +1,17 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+fn incr(m: &mut i64) {
+    *m += 1;
+}
+
+// A call ends its basic block, so the second call sees `f` re-entering the block
+// it lives in. The callee's specification must survive that boundary; without it
+// the second call's effect on `x` is unconstrained.
+fn main() {
+    let f: fn(&mut i64) = incr;
+    let mut x = 0;
+    f(&mut x);
+    f(&mut x);
+    assert!(x == 2);
+}

--- a/tests/ui/pass/fn_ptr_in_tuple_call_twice.rs
+++ b/tests/ui/pass/fn_ptr_in_tuple_call_twice.rs
@@ -1,0 +1,15 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+fn add1(x: i64) -> i64 {
+    x + 1
+}
+
+// The specification has to reach a function type nested inside another type, not
+// just one a local holds directly.
+fn main() {
+    let p: (fn(i64) -> i64,) = (add1,);
+    let a = (p.0)(0);
+    let b = (p.0)(a);
+    assert!(b == 2);
+}

--- a/tests/ui/pass/fn_ptr_param_call_twice.rs
+++ b/tests/ui/pass/fn_ptr_param_call_twice.rs
@@ -1,0 +1,26 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand() -> i64 { unimplemented!() }
+
+fn incr(m: &mut i64) {
+    *m += 1;
+}
+
+// A call ends its basic block, so the second call sees `f` re-entering the block
+// it lives in. The specification the caller supplied for `f` must survive that
+// boundary; without it the second call's effect on `x` is unconstrained.
+fn app(f: fn(&mut i64), mut x: i64) -> i64 {
+    f(&mut x);
+    f(&mut x);
+    x
+}
+
+fn main() {
+    let i = rand();
+    let x = app(incr, i);
+    assert!(x == i + 2);
+}


### PR DESCRIPTION
Fixes #201.

## Root cause

A block that inherits its precondition gets two things and no more: the target's parameters, typed from their MIR types alone, and a formula capturing what the predecessor's env says about each parameter's **value**.

`PrecondCapture` is where the second part is assembled, and it only ever reads a value:

```rust
fn push(&mut self, target: ..., var_ty: PlaceType) {
    self.body.push_conj(var_ty.formula...);            // the formula
    self.target_equations.push((target, var_ty.term...)); // the term
    // var_ty.ty is not read
}
```

and `push_env_state` folds in `rty.refinement` — the outer refinement of `{ T | phi }` — leaving `T` alone. So everything a type states *by itself* is dropped at the boundary and rebuilt unrefined from MIR: the refinements nested inside it, and the specification a function type spells out.

A fn-pointer value is where this becomes visible, because a function type has nowhere else to keep its specification. `type_call` reads the pointer through `operand_type(func).ty`, gets an unrefined `(..) -> ..`, and `relate_fn_sub_type` relates the call against `true`, leaving the result unconstrained.

Before, for `let f: fn(i64) -> i64 = add1; let a = f(0); let b = f(a);`:

```
register_basic_block_def bb=bb1 rty=(_0: (), _1: (int) → int, _2: int) → () has_precondition=false

fn_sub_type got=({ int | p0 ν }) → { int | p1 ν $0 }   expected=({ int | ν = 0 }) → { int | p6 ν }     ; bb0
fn_sub_type got=(int) → int                            expected=({ int | ν = _2 }) → { int | p7 ν _2 }  ; bb1
```

## Trigger

The trigger is the block, not the number of calls: a call is a terminator, so the first call in a body sits in the reify cast's own block and is typed precisely, while every later one does not. A single call behind a branch reproduces it just as well.

It is not limited to `ReifyFnPointer` locals, nor to the root of a type. A fn-pointer **parameter** hits the same path once it is called from a later block, and so does a fn pointer nested in a tuple.

## Change

`install_inherited_bb_ty` already materializes a goto target's type from the predecessor's env, so it now hands the env's types over there too, alongside the precondition it was already capturing.

A type in the env is closed: a refinement nested in one constrains the value at its own position and names nothing from the env. So the type transfers as it stands, with no substitution — `assert_closed` states that invariant where it is relied on. The sort assertion beside it holds the env's view and the MIR-built parameter to the same shape.

Blocks that need their own precondition are untouched. Those get template types and relate the two sides at the goto, and that relation — being structural — already carried all of this, nested positions included.

## Why not relate the types at the goto here too

Because on this path there is nothing to relate against:

```rust
if !needs_own_precondition(&self.body, bb) {
    self.install_inherited_bb_ty(bb, outer_fn_param_vars);
    return;                       // <- no relation happens on this path
}
```

The target's type comes from `TypeBuilder::build_basic_block`, which registers no templates (its `FakeRegistry` panics if asked to). With no predicate variables in the expected type, a subtyping relation yields `true ⟹ true`, and the block body goes on reading its parameters from that same type.

Sending these blocks down the predicate-variable path instead was tried and is not a one-line change: it makes `pass/option_unwrap_or_else` and `fail/option_unwrap_or_else` abort in `type_goto`, where `assert_closed` meets a parameter type that is not closed, and it pushes `pass/closure_receiver_mut_model` past a 150s solver timeout. Unifying the two paths looks worthwhile but wants that invariant sorted out first.

## Testing

- `tests/ui/{pass,fail}/fn_ptr_call_twice.rs`, `fn_ptr_call_in_branch.rs`, `fn_ptr_param_call_twice.rs`, and `fn_ptr_in_tuple_call_twice.rs` added. Each `fail` one is the `pass` one with the property broken as narrowly as possible. The last pins the nested case, which a version of this change that looked only at the root of a type did not fix.
- All three reproducers from the issue verify as `safe`, and every row of the issue's behavior matrix matches its Expected column.
- Soundness spot-checks still report `Unsat`: `b == 3` and `b == 1` on the two-call program, `x == 3` on the `&mut` one, the branch variant, the two-target variant, and a fn pointer chosen by a branch (`if c { add1 } else { add2 }`).
- `cargo test` with the PCSat tests filtered out: 284 passed, 0 failed, plus 3 unit tests and 2 doc-tests.
- The 32 PCSat tests were run directly, sequentially, on this branch and on `main` at cd33fbf, with identical verdicts: 31 as expected on both, and `fail/option_map.rs` undecided on both at a 150s solver timeout.
- The closedness `assert_closed` relies on was measured before relying on it: instrumented to report any variable occurring in an env type at a goto, then run over all 316 test files. No occurrences.
- `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` are clean.

Two things found while testing, neither addressed here:

- A pre-existing ICE, filed as #217: a null-sorted value (`fn(..)` pointer or `&str`) stored in an aggregate that **also** has a non-singleton field aborts in constraint construction. It reproduces identically on `main`. That is why `fn_ptr_in_tuple_call_twice` uses a one-element tuple.
- The emitted SMT-LIB2 is not reproducible across runs — the same binary on the same input emits the same clauses with bound variables permuted, so `THRUST_OUTPUT_DIR` dumps cannot be diffed to compare two builds. Worth a separate issue if determinism there is wanted.

Since the fix is not specific to function pointers, #201's framing is narrower than the defect. Happy to retitle it, or to leave it as the fn-pointer symptom and open a separate issue for the general loss — whichever you prefer.