### PR TITLE
Close non-last parameter types of function templates

### DIFF
--- a/src/refine/template.rs
+++ b/src/refine/template.rs
@@ -625,8 +625,8 @@ where
                         rty::RefinedType::unrefined(
                             self.inner
                                 .for_template(self.registry)
-                                .with_scope(&builder)
-                                .build(param_ty.ty),
+                                .build(param_ty.ty)
+                                .vacuous(),
                         )
                     }
                 });

--- a/tests/ui/fail/option_param_order.rs
+++ b/tests/ui/fail/option_param_order.rs
@@ -1,0 +1,15 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+fn get_or(o: Option<i64>, d: i64) -> i64 {
+    match o {
+        Some(x) => x,
+        None => d,
+    }
+}
+
+fn main() {
+    assert!(get_or(Some(1), 9) == 1);
+    // `get_or` returns the default in the `None` case, so this assertion does not hold
+    assert!(get_or(None, 9) == 1);
+}

--- a/tests/ui/pass/option_param_order.rs
+++ b/tests/ui/pass/option_param_order.rs
@@ -1,0 +1,14 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+fn get_or(o: Option<i64>, d: i64) -> i64 {
+    match o {
+        Some(x) => x,
+        None => d,
+    }
+}
+
+fn main() {
+    assert!(get_or(Some(1), 9) == 1);
+    assert!(get_or(None, 9) == 9);
+}


### PR DESCRIPTION
Fixes #235.

`FunctionTemplateTypeBuilder::build` gave a non-last parameter's type the scope of the parameters before it. Nothing in that type carries a template except an enum's type arguments, which `TemplateTypeBuilder::build` refines via `build_refined`, so for a parameter whose type contains a generic enum the scope leaked into the resulting type and left it open.

`BasicBlockType::params` holds the enclosing function's arguments, and `analyze::basic_block` instantiates each of them against the caller's variable through `assert_closed`. A generic enum in any parameter but the last one therefore aborted with `unexpected variable` as soon as the body had a block needing its own precondition:

```rust
fn get_or(o: Option<i64>, d: i64) -> i64 {
    match o { Some(x) => x, None => d }
}
```

This builds such a parameter without the scope. The last parameter's own type is already built that way inside `build_refined` — only its refinement is scoped — so the two paths now agree.

The alternative repair sketched in the issue (carrying the enum-argument templates through the basic-block parameter instead of calling `assert_closed`) is not taken here: the scope only ever reached enum type arguments, incidentally, and it never reached the last parameter's type at all, so dropping it is the smaller and more consistent change.

## Testing

- `tests/ui/{pass,fail}/option_param_order.rs`: the `get_or` shape above, with the `fail` file breaking only the `None`-case assertion. Both ICE (exit 101) on `main` and pass here.
- All 13 rows of the issue's isolation table verify as `safe`, including the `&self`-method shape, and the three soundness spot-checks it lists are still rejected as `Unsat`.
- `cargo test`: 326 UI tests, 2 doc-tests passing; `cargo fmt --check` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3XpZ2MXjgs3JoodCr8iA9)_