### PR TITLE
Analyze the impl body a trait-dispatched call resolves to

### DIFF
--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -926,6 +926,11 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         args: mir_ty::GenericArgsRef<'tcx>,
     ) -> rty::Type<rty::Closed> {
         if let Some(def_ty) = self.ctx.def_ty_with_args(def_id, args) {
+            let (impl_def_id, impl_args) = self.resolve_fn_def(def_id, args);
+            // otherwise nothing asks for a deferred impl method's type and its body goes unchecked
+            if impl_def_id != def_id {
+                let _ = self.ctx.def_ty_with_args(impl_def_id, impl_args);
+            }
             return def_ty.ty;
         }
 

--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -192,7 +192,9 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         Some(trait_item_id)
     }
 
-    pub fn trait_item_ty(&mut self) -> Option<rty::RefinedType> {
+    /// The generic arguments the implemented trait method takes for the instantiation
+    /// being analyzed.
+    pub fn trait_item_args(&self) -> Option<mir_ty::GenericArgsRef<'tcx>> {
         let impl_did = self.tcx.parent(self.local_def_id.to_def_id());
 
         if self.tcx.def_kind(impl_did) != (rustc_hir::def::DefKind::Impl { of_trait: true }) {
@@ -204,12 +206,25 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             .tcx
             .impl_trait_ref(impl_did)?
             .instantiate(self.tcx, self.generic_args);
+        // ... and end with the method's own, which the trait method is generic over as well
+        let own_args = self
+            .generic_args
+            .iter()
+            .skip(self.tcx.generics_of(self.local_def_id).parent_count);
+        Some(
+            self.tcx
+                .mk_args_from_iter(trait_ref.args.iter().chain(own_args)),
+        )
+    }
+
+    pub fn trait_item_ty(&mut self) -> Option<rty::RefinedType> {
+        let trait_item_args = self.trait_item_args()?;
         let trait_item_did = self
             .tcx
             .associated_item(self.local_def_id.to_def_id())
             .trait_item_def_id
             .unwrap();
-        self.ctx.def_ty_with_args(trait_item_did, trait_ref.args)
+        self.ctx.def_ty_with_args(trait_item_did, trait_item_args)
     }
 
     // TODO: Remove this eager precompute together with
@@ -257,14 +272,16 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             .ctx
             .extract_ensure_annot(self.local_def_id, self.generic_args);
 
-        if let Some(trait_item_id) = self.local_trait_item_id() {
+        if let Some((trait_item_id, trait_item_args)) =
+            self.local_trait_item_id().zip(self.trait_item_args())
+        {
             tracing::info!("trait item found: {:?}", trait_item_id);
             let trait_require_annot = self
                 .ctx
-                .extract_require_annot(trait_item_id, self.generic_args);
+                .extract_require_annot(trait_item_id, trait_item_args);
             let trait_ensure_annot = self
                 .ctx
-                .extract_ensure_annot(trait_item_id, self.generic_args);
+                .extract_ensure_annot(trait_item_id, trait_item_args);
 
             assert!(require_annot.is_none() || trait_require_annot.is_none());
             require_annot = require_annot.or(trait_require_annot);

--- a/src/analyze/local_def.rs
+++ b/src/analyze/local_def.rs
@@ -45,6 +45,7 @@ pub struct Analyzer<'tcx, 'ctx> {
     local_def_id: LocalDefId,
 
     body: Body<'tcx>,
+    /// the instantiation of the def's generic parameters being analyzed, also used
     /// to substitute HIR types during translation in [`crate::analyze::annot_fn`]
     generic_args: mir_ty::GenericArgsRef<'tcx>,
     drop_points: HashMap<BasicBlock, analyze::basic_block::DropPoints>,
@@ -198,7 +199,11 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
             return None;
         }
 
-        let trait_ref = self.tcx.impl_trait_ref(impl_did)?.instantiate_identity();
+        // an associated method's generic arguments start with those of its impl
+        let trait_ref = self
+            .tcx
+            .impl_trait_ref(impl_did)?
+            .instantiate(self.tcx, self.generic_args);
         let trait_item_did = self
             .tcx
             .associated_item(self.local_def_id.to_def_id())
@@ -1115,7 +1120,7 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
         let body = tcx.optimized_mir(local_def_id.to_def_id()).clone();
         let drop_points = Default::default();
         let type_builder = TypeBuilder::new(tcx, ctx.def_ids(), local_def_id.to_def_id());
-        let generic_args = tcx.mk_args(&[]);
+        let generic_args = mir_ty::GenericArgs::identity_for_item(tcx, local_def_id);
         Self {
             ctx,
             tcx,

--- a/tests/ui/fail/trait_generic_impl.rs
+++ b/tests/ui/fail/trait_generic_impl.rs
@@ -1,0 +1,29 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::context]
+trait Tr {
+    #[thrust_macros::requires(true)]
+    #[thrust_macros::ensures(result > 0)]
+    fn m(&self) -> i32;
+}
+
+struct W<T>(T);
+
+impl<T> thrust_models::Model for W<T>
+where
+    T: thrust_models::Model,
+{
+    type Ty = Self;
+}
+
+impl<T> Tr for W<T> {
+    fn m(&self) -> i32 {
+        -1
+    }
+}
+
+fn main() {
+    let w = W(0i32);
+    assert!(w.m() > 0);
+}

--- a/tests/ui/fail/trait_generic_method.rs
+++ b/tests/ui/fail/trait_generic_method.rs
@@ -1,0 +1,29 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::context]
+trait Tr {
+    #[thrust_macros::requires(true)]
+    #[thrust_macros::ensures(result > 0)]
+    fn m<U>(&self, u: U) -> i32;
+}
+
+struct W<T>(T);
+
+impl<T> thrust_models::Model for W<T>
+where
+    T: thrust_models::Model,
+{
+    type Ty = Self;
+}
+
+impl<T> Tr for W<T> {
+    fn m<U>(&self, _u: U) -> i32 {
+        -1
+    }
+}
+
+fn main() {
+    let w = W(0i32);
+    assert!(w.m(0i64) > 0);
+}

--- a/tests/ui/pass/trait_generic_impl.rs
+++ b/tests/ui/pass/trait_generic_impl.rs
@@ -1,0 +1,29 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::context]
+trait Tr {
+    #[thrust_macros::requires(true)]
+    #[thrust_macros::ensures(result > 0)]
+    fn m(&self) -> i32;
+}
+
+struct W<T>(T);
+
+impl<T> thrust_models::Model for W<T>
+where
+    T: thrust_models::Model,
+{
+    type Ty = Self;
+}
+
+impl<T> Tr for W<T> {
+    fn m(&self) -> i32 {
+        1
+    }
+}
+
+fn main() {
+    let w = W(0i32);
+    assert!(w.m() > 0);
+}

--- a/tests/ui/pass/trait_generic_method.rs
+++ b/tests/ui/pass/trait_generic_method.rs
@@ -1,0 +1,29 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::context]
+trait Tr {
+    #[thrust_macros::requires(true)]
+    #[thrust_macros::ensures(result > 0)]
+    fn m<U>(&self, u: U) -> i32;
+}
+
+struct W<T>(T);
+
+impl<T> thrust_models::Model for W<T>
+where
+    T: thrust_models::Model,
+{
+    type Ty = Self;
+}
+
+impl<T> Tr for W<T> {
+    fn m<U>(&self, _u: U) -> i32 {
+        1
+    }
+}
+
+fn main() {
+    let w = W(0i32);
+    assert!(w.m(0i64) > 0);
+}


### PR DESCRIPTION
Closes #190.

A generic `impl` of a trait method is registered as a deferred def, whose body is analyzed only when its type is asked for. A call dispatched through the trait takes its type from the trait method instead — that is where the spec is annotated — so nothing ever asked for the impl method's type: its body went unchecked while every caller assumed the trait's `ensures`, and an always-panicking program verified as `safe`.

## Changes

- `src/analyze/basic_block.rs`: when `fn_def_ty` answers from the registered callee type, it now also asks for the type of the impl the call resolves to, which is what analyzes that impl's body. The impl method's expected type is the trait's spec, so running its body against it is the missing check. The lookup sits at the call site rather than in `def_ty_with_args` so that it resolves in the caller body's typing env and reuses `resolve_fn_def`.
- `src/analyze/local_def.rs`: `trait_item_args` builds the implemented trait method's arguments for the instantiation being analyzed — the instantiated trait ref followed by the impl method's own-parameter tail — and both the trait-item type lookup and the inherited `requires`/`ensures` extraction use it. `Analyzer::new` now defaults `generic_args` to the identity instantiation, which keeps that instantiation well-formed for a def whose generic arguments were never set.
- `tests/ui/{pass,fail}/trait_generic_impl.rs`: a generic `impl` of a spec'd trait method, with the `ensures` satisfied and violated.
- `tests/ui/{pass,fail}/trait_generic_method.rs`: the same for a trait method generic over a parameter of its own, which the newly reached path had to get right.

## Verification

`cargo test` (330 UI tests), `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` all pass, with Z3 5.0.0 and the CI-pinned COAR image.

Beyond the added test pairs, checked by hand: the issue's reproduction and its `assert!(false)`-with-unused-result variant are both rejected; a satisfied body, a bounded `impl<T: Base>`, two instantiations (`W<i32>` and `W<bool>`), a non-generic method in a generic impl, and the method passed as a function value all verify or are rejected as they should be.