### PR TITLE
Do not reborrow the operand of PtrMetadata

### DIFF
--- a/src/analyze/basic_block/visitor/reborrow.rs
+++ b/src/analyze/basic_block/visitor/reborrow.rs
@@ -95,6 +95,16 @@ impl<'a, 'tcx, 'ctx> mir::visit::MutVisitor<'tcx> for ReborrowVisitor<'a, 'tcx, 
         self.super_assign(place, rvalue, location);
     }
 
+    fn visit_rvalue(&mut self, rvalue: &mut mir::Rvalue<'tcx>, location: mir::Location) {
+        // `PtrMetadata` only reads the length out of the reference it is applied to, so its
+        // operand needs no reborrow. `analyze_assignment` takes the shared borrow it needs.
+        if let mir::Rvalue::UnaryOp(mir::UnOp::PtrMetadata, _) = rvalue {
+            return;
+        }
+
+        self.super_rvalue(rvalue, location);
+    }
+
     // TODO: is it always true that the operand is not referred again in rvalue
     fn visit_operand(&mut self, operand: &mut mir::Operand<'tcx>, location: mir::Location) {
         let Some(p) = operand.place() else {

--- a/tests/ui/fail/slice_len_guard_mut.rs
+++ b/tests/ui/fail/slice_len_guard_mut.rs
@@ -1,0 +1,12 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off -C opt-level=2
+
+#[thrust::callable]
+fn check(v: &mut [i32], i: usize) {
+    if i < v.len() {
+        v[i] = 7;
+        assert!(v[i] == 8);
+    }
+}
+
+fn main() {}

--- a/tests/ui/pass/slice_len_guard_mut.rs
+++ b/tests/ui/pass/slice_len_guard_mut.rs
@@ -1,0 +1,16 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off -C opt-level=2
+
+// At `-C opt-level=1` and above rustc reads slice metadata straight off the `&mut [i32]`
+// local (`_len = PtrMetadata(copy _v)`) instead of through a shared reborrow, so this pins
+// down that the length `len()` returns still describes the referent the guarded index
+// reads.
+#[thrust::callable]
+fn check(v: &mut [i32], i: usize) {
+    if i < v.len() {
+        v[i] = 7;
+        assert!(v[i] == 7);
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #240.

`<[T]>::len` is lowered to `PtrMetadata`. From `-C opt-level=1` upward rustc applies it directly to the `&mut [T]` local (`_len = PtrMetadata(copy _v)`) rather than through the shared reborrow it inserts at `-C opt-level=0`, so `ReborrowVisitor::visit_operand` rewrote the operand into a fresh `&mut` reborrow.

`analyze_assignment` then discarded that reborrow and took its own shared borrow of the referent, leaving the reborrow's prophecy unresolved: the synthetic local is absent from the MIR `DropPoints` was computed over, so nothing ever equated it to its current value. Since borrowing a place replaces its value with the prophecy, `*v` was havoc'd for the rest of the function and `if i < v.len()` no longer discharged the bound on the following `v[i]`.

`PtrMetadata` only reads the length out of its operand, so this skips the reborrow and lets `analyze_assignment` borrow the referent itself — which it already does.

## Testing

Verified against Z3 5.0.0 and the COAR image CI pins.

The behavior matrix in the issue is now green in every cell: `-C opt-level=0,1,2,3,s,z` × the `&mut [i32]` reader, the `&[i32]` reader, the `&mut [i32]` writer and `double_all`.

This is an over-rejection fix, not a vacuity one — the unsafe variants stay rejected, and a genuine write-then-read verifies:

| program | opt=0 | opt=2 |
|---|---|---|
| `if i < v.len() { let x = v[i]; assert!(x == 0); }` | Unsat | Unsat |
| `if i < v.len() { v[i] = 7; assert!(v[i] == 8); }` | Unsat | Unsat |
| unguarded `let x = v[i];` | Unsat | Unsat |
| `if i < v.len() { v[i] = 7; assert!(v[i] == 7); }` | safe | safe |

`cargo test` passes (328 UI tests, plus unit and doc tests); `cargo fmt --check` and `cargo clippy --all-targets` are clean.

## Tests added

A `pass`/`fail` pair at `-C opt-level=2`, so the suite exercises the `PtrMetadata(copy <&mut>)` shape that CI never saw before:

- `tests/ui/pass/slice_len_guard_mut.rs` — `if i < v.len() { v[i] = 7; assert!(v[i] == 7); }`
- `tests/ui/fail/slice_len_guard_mut.rs` — the same with the asserted value broken to `8`

---
_Generated by [Claude Code](https://claude.ai/code/session_017rubDn1kuLtPnuRoLkkXTj)_