### PR TITLE
Sign-extend SwitchInt targets of signed discriminants

### DIFF
--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -852,14 +852,22 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     ) where
         F: FnMut(&mut Self, BasicBlock),
     {
+        let discr_mir_ty = discr.ty(&self.local_decls, self.tcx);
         let discr_ty = self.operand_type(discr);
         let mut negations = Vec::new();
-        for (val, bb) in targets.iter() {
-            let val: i64 = val.try_into().unwrap();
-            let target_term = match (val, &discr_ty.ty) {
+        for (bits, bb) in targets.iter() {
+            let target_term = match (bits, &discr_ty.ty) {
                 (0, rty::Type::Bool) => chc::Term::bool(false),
                 (1, rty::Type::Bool) => chc::Term::bool(true),
-                (n, rty::Type::Int) => chc::Term::int(n),
+                (_, rty::Type::Int) => {
+                    let (size, signed) = discr_mir_ty.int_size_and_signed(self.tcx);
+                    let val: i64 = if signed {
+                        size.sign_extend(bits).try_into().unwrap()
+                    } else {
+                        bits.try_into().unwrap()
+                    };
+                    chc::Term::int(val)
+                }
                 _ => unimplemented!(),
             };
 

--- a/tests/ui/fail/switch_int_negative.rs
+++ b/tests/ui/fail/switch_int_negative.rs
@@ -1,0 +1,15 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand() -> i32 { unimplemented!() }
+
+fn main() {
+    let x = rand();
+    match x {
+        -1 => assert!(x > 0),
+        _ => {}
+    }
+}

--- a/tests/ui/pass/switch_int_negative.rs
+++ b/tests/ui/pass/switch_int_negative.rs
@@ -1,0 +1,15 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(true)]
+#[thrust::trusted]
+fn rand() -> i32 { unimplemented!() }
+
+fn main() {
+    let x = rand();
+    match x {
+        -1 => assert!(x < 0),
+        _ => {}
+    }
+}


### PR DESCRIPTION
Fixes #132.

`mir::SwitchTargets::iter()` yields each case as the discriminant type's bit pattern zero-extended into a `u128`, and `type_switch_int` converted it with `val.try_into::<i64>().unwrap()`. For a signed discriminant a negative case therefore arrived as a large positive number — the `-1` arm of an `i32` match was pinned to `4294967295`. The discriminant operand itself is modeled as its true value, so such an arm was verified under a path assumption nothing satisfies (silently accepting programs that panic), while a comparison against a negative literal was rejected as unreachable. An `i64` discriminant hit the `try_into().unwrap()` instead.

The `Int` case now takes the width and signedness from the discriminant's MIR type (`Ty::int_size_and_signed`) and sign-extends the bit pattern (`Size::sign_extend`) before building the literal.

## Behavior

| program | before | after |
| --- | --- | --- |
| `match x { -1 => assert!(x > 0), _ => {} }` (panics at runtime) | accepted as safe (unsound) | `Unsat` |
| `let x: i32 = -1; assert!(x == -1)` | `Unsat` | accepted |
| `a.signum()`, `a < 0 => s == -1` | `Unsat` | accepted |
| negative literal against an `i64` | `TryFromIntError` panic | accepted |
| `match x { 1 => assert!(x > 1), _ => {} }` (positive control) | `Unsat` | `Unsat` |

## Tests

`tests/ui/{pass,fail}/switch_int_negative.rs`. Before the change the `pass` file is reported `Unsat` and the `fail` file is accepted; after it, the reverse — so the pair pins both faces of the bug. Full `cargo test` (330 UI tests) passes, as do `cargo fmt --check` and `cargo clippy --all-targets`.