### PR TITLE
Declare the sorts of quantifier binders in the emitted SMT-LIB2

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -7,7 +7,7 @@
 //! CHC solver with the [`Analyzer::solve`] and subsequently reports the result.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use rustc_hir::lang_items::LangItem;
@@ -376,6 +376,45 @@ impl<'tcx> Analyzer<'tcx> {
         self.system.borrow_mut().datatypes.push(datatype);
 
         enum_def
+    }
+
+    /// Registers the definitions of the enums `ty` is built from, including the ones reachable
+    /// through the fields of the datatypes it mentions.
+    pub fn register_enum_defs_in_ty(&self, type_builder: &TypeBuilder<'tcx>, ty: mir_ty::Ty<'tcx>) {
+        use mir_ty::{TypeSuperVisitable as _, TypeVisitable as _};
+        struct EnumCollector<'a, 'tcx> {
+            tcx: TyCtxt<'tcx>,
+            builder: &'a TypeBuilder<'tcx>,
+            enums: HashSet<DefId>,
+            visited: HashSet<mir_ty::Ty<'tcx>>,
+        }
+        impl<'tcx> mir_ty::TypeVisitor<TyCtxt<'tcx>> for EnumCollector<'_, 'tcx> {
+            fn visit_ty(&mut self, ty: mir_ty::Ty<'tcx>) {
+                let ty = self.builder.resolve_model_ty(ty);
+                if let mir_ty::TyKind::Adt(def, args) = ty.kind() {
+                    if self.visited.insert(ty) {
+                        if def.is_enum() {
+                            self.enums.insert(def.did());
+                        }
+                        for field in def.all_fields() {
+                            field.ty(self.tcx, args).visit_with(self);
+                        }
+                    }
+                }
+                ty.super_visit_with(self);
+            }
+        }
+
+        let mut visitor = EnumCollector {
+            tcx: self.tcx,
+            builder: type_builder,
+            enums: HashSet::new(),
+            visited: HashSet::new(),
+        };
+        ty.visit_with(&mut visitor);
+        for def_id in visitor.enums {
+            self.get_or_register_enum_def(def_id);
+        }
     }
 
     pub fn register_def(&mut self, def_id: DefId, rty: rty::RefinedType) {

--- a/src/analyze/annot_fn.rs
+++ b/src/analyze/annot_fn.rs
@@ -617,6 +617,8 @@ impl<'a, 'tcx> AnnotFnTranslator<'a, 'tcx> {
                 );
             };
             let param_ty = self.pat_ty(param.pat);
+            self.analyzer
+                .register_enum_defs_in_ty(&self.type_builder, param_ty);
             let sort = self.type_builder.build(param_ty).to_sort();
             let var_term = chc::Term::FormulaQuantifiedVar(sort.clone(), ident.name.to_string());
             inner_translator.env.insert(hir_id, var_term);

--- a/src/analyze/basic_block.rs
+++ b/src/analyze/basic_block.rs
@@ -1433,40 +1433,9 @@ impl<'tcx, 'ctx> Analyzer<'tcx, 'ctx> {
     }
 
     fn register_enum_defs(&mut self) {
-        use mir_ty::{TypeSuperVisitable as _, TypeVisitable as _};
-        struct EnumCollector<'tcx> {
-            tcx: mir_ty::TyCtxt<'tcx>,
-            builder: TypeBuilder<'tcx>,
-            enums: std::collections::HashSet<DefId>,
-            visited: std::collections::HashSet<mir_ty::Ty<'tcx>>,
-        }
-        impl<'tcx> mir_ty::TypeVisitor<mir_ty::TyCtxt<'tcx>> for EnumCollector<'tcx> {
-            fn visit_ty(&mut self, ty: mir_ty::Ty<'tcx>) {
-                let ty = self.builder.resolve_model_ty(ty);
-                if let mir_ty::TyKind::Adt(def, args) = ty.kind() {
-                    if self.visited.insert(ty) {
-                        if def.is_enum() {
-                            self.enums.insert(def.did());
-                        }
-                        for field in def.all_fields() {
-                            field.ty(self.tcx, args).visit_with(self);
-                        }
-                    }
-                }
-                ty.super_visit_with(self);
-            }
-        }
-        let mut visitor = EnumCollector {
-            tcx: self.tcx,
-            builder: self.type_builder.clone(),
-            enums: std::collections::HashSet::new(),
-            visited: std::collections::HashSet::new(),
-        };
         for local_decl in &self.local_decls {
-            local_decl.ty.visit_with(&mut visitor);
-        }
-        for def_id in visitor.enums {
-            self.ctx.get_or_register_enum_def(def_id);
+            self.ctx
+                .register_enum_defs_in_ty(&self.type_builder, local_decl.ty);
         }
     }
 }

--- a/src/chc.rs
+++ b/src/chc.rs
@@ -1365,6 +1365,11 @@ impl<V> Atom<V> {
         self.args.iter().flat_map(|t| t.fv()).chain(guard_fvs)
     }
 
+    /// Iterates over the variables bound by the quantifiers of the guard.
+    pub fn iter_quantified_vars(&self) -> impl Iterator<Item = &(String, Sort)> {
+        self.guard.iter().flat_map(|g| g.iter_quantified_vars())
+    }
+
     pub fn guarded(self, new_guard: Formula<V>) -> Atom<V> {
         let Atom {
             guard: self_guard,
@@ -1651,6 +1656,26 @@ impl<V> Formula<V> {
         }
     }
 
+    /// Iterates over the variables bound by the quantifiers occurring in this formula.
+    pub fn iter_quantified_vars(&self) -> impl Iterator<Item = &(String, Sort)> {
+        self.iter_quantified_vars_impl()
+    }
+
+    fn iter_quantified_vars_impl(&self) -> Box<dyn Iterator<Item = &(String, Sort)> + '_> {
+        match self {
+            Formula::Atom(atom) => Box::new(atom.iter_quantified_vars()),
+            Formula::Not(fo) => Box::new(fo.iter_quantified_vars()),
+            Formula::And(fs) => Box::new(fs.iter().flat_map(Formula::iter_quantified_vars)),
+            Formula::Or(fs) => Box::new(fs.iter().flat_map(Formula::iter_quantified_vars)),
+            Formula::Implies(lhs, rhs) => {
+                Box::new(lhs.iter_quantified_vars().chain(rhs.iter_quantified_vars()))
+            }
+            Formula::Exists(vars, fo) | Formula::Forall(vars, fo) => {
+                Box::new(vars.iter().chain(fo.iter_quantified_vars()))
+            }
+        }
+    }
+
     pub fn push_conj(&mut self, other: Self) {
         match self {
             Formula::And(fs) => {
@@ -1822,6 +1847,13 @@ impl<V> Body<V> {
 
     pub fn iter_atoms(&self) -> impl Iterator<Item = &Atom<V>> {
         self.formula.iter_atoms().chain(&self.atoms)
+    }
+
+    /// Iterates over the variables bound by the quantifiers occurring in this body.
+    pub fn iter_quantified_vars(&self) -> impl Iterator<Item = &(String, Sort)> {
+        self.formula
+            .iter_quantified_vars()
+            .chain(self.atoms.iter().flat_map(Atom::iter_quantified_vars))
     }
 }
 

--- a/src/chc/format_context.rs
+++ b/src/chc/format_context.rs
@@ -226,6 +226,11 @@ fn collect_sorts(system: &chc::System) -> BTreeSet<chc::Sort> {
         for a in clause.body.iter_atoms() {
             atom_sorts(clause, a, &mut sorts);
         }
+        let quantified_vars = clause
+            .head
+            .iter_quantified_vars()
+            .chain(clause.body.iter_quantified_vars());
+        sorts.extend(quantified_vars.map(|(_, sort)| sort.clone()));
     }
 
     for sort in sorts.clone() {

--- a/tests/ui/fail/annot_exists_enum_binder.rs
+++ b/tests/ui/fail/annot_exists_enum_binder.rs
@@ -1,0 +1,22 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -Adead_code -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::exists;
+
+pub enum X {
+    A(i64),
+    B(bool),
+}
+
+impl thrust_models::Model for X {
+    type Ty = X;
+}
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(exists(|x: X| result < 0))]
+fn f() -> i64 {
+    1
+}
+
+fn main() {}

--- a/tests/ui/fail/annot_exists_tuple_binder.rs
+++ b/tests/ui/fail/annot_exists_tuple_binder.rs
@@ -1,0 +1,13 @@
+//@error-in-other-file: Unsat
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::exists;
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(exists(|p: (i64, bool)| result < 0))]
+fn f() -> i64 {
+    1
+}
+
+fn main() {}

--- a/tests/ui/pass/annot_exists_enum_binder.rs
+++ b/tests/ui/pass/annot_exists_enum_binder.rs
@@ -1,0 +1,22 @@
+//@check-pass
+//@compile-flags: -Adead_code -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::exists;
+
+pub enum X {
+    A(i64),
+    B(bool),
+}
+
+impl thrust_models::Model for X {
+    type Ty = X;
+}
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(exists(|x: X| result >= 0))]
+fn f() -> i64 {
+    1
+}
+
+fn main() {}

--- a/tests/ui/pass/annot_exists_tuple_binder.rs
+++ b/tests/ui/pass/annot_exists_tuple_binder.rs
@@ -1,0 +1,13 @@
+//@check-pass
+//@compile-flags: -C debug-assertions=off
+//@rustc-env: THRUST_SOLVER=tests/thrust-pcsat-wrapper
+
+use thrust_models::exists;
+
+#[thrust_macros::requires(true)]
+#[thrust_macros::ensures(exists(|p: (i64, bool)| result >= 0))]
+fn f() -> i64 {
+    1
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #142.

`collect_sorts` gathers the sorts to declare from predicate signatures, clause variables and atom arguments. `iter_atoms` descends into the body of an `Exists`/`Forall`, but the binder list is metadata no atom references, so a sort that appears only as a binder is never collected and the query names an undefined sort — rejected while parsing, by any backend.

Fixing that alone turns the reported program into an ICE rather than a fix: enum definitions are collected from the local declarations of the body under analysis (`basic_block::Analyzer::register_enum_defs`), so an enum a specification only mentions as the type of a quantified variable is not in `system.datatypes` at all, and `monomorphize_datatype` unwraps a `None` on the now-collected sort. Both halves are needed.

## Reading order

The diff is 4 source files, but only ~40 lines carry behavior; the commits are meant to be read one by one.

| commit | what to check |
|---|---|
| `7272014` Lift the enum definition collection out of the basic block analyzer | Pure move — `EnumCollector` is unchanged, it takes the `TypeBuilder` by reference instead of cloning it and walks one type per call instead of a loop of locals. The one behavioral nuance: `visited` no longer spans the whole local list, which only means a type shared by two locals is walked twice; `get_or_register_enum_def` is idempotent. |
| `4f232a3` Register the enums a quantified variable's type is built from | Two lines in `AnnotFnTranslator::to_formula_with_quantified_vars`. No effect on its own — nothing yet asks for the binder's sort. |
| `9ef66ff` Declare the sorts of quantifier binders in the emitted SMT-LIB2 | The actual fix plus the tests: `iter_quantified_vars` on `Formula`/`Atom`/`Body` in `chc.rs`, mirroring the shape of `iter_atoms`/`fv` next to them, and five lines in `collect_sorts`. |

`Atom::iter_quantified_vars` covers the guard because `smtlib2::Atom` renders it as `(=> guard ...)`, so a quantifier there needs its sorts declared too, exactly like one in the body formula. The issue also suggests inserting the sort in the `FormulaQuantifiedVar` arm of `term_sorts`; that arm is already covered by the `sorts.insert(clause.term_sort(t))` at the top of the function, so it is left alone.

## Testing

Verified against Z3 5.0.0 and the COAR image CI pins. `cargo test` passes (332 UI tests, plus doc tests); `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

The program from the issue, which reported `unknown sort 'E'` before:

```console
$ THRUST_OUTPUT_DIR=/tmp/out cargo run -q -- -Adead_code -C debug-assertions=false repro.rs
$ grep -c declare-datatype /tmp/out/thrust_output.smt2
1
```

Under Z3 the query is now well-formed but comes back `unknown`, as any quantified specification does; under PCSat it verifies.

## Tests added

Two `pass`/`fail` pairs, both quantifying over a sort that appears nowhere else in the clause, which is what it takes to reach the bug — a binder used in the body has its sort collected through the atom arguments already:

- `tests/ui/{pass,fail}/annot_exists_enum_binder.rs` — an enum-sorted binder, the case in the issue
- `tests/ui/{pass,fail}/annot_exists_tuple_binder.rs` — a tuple-sorted binder, the second reproduction in the issue

One caveat worth knowing before reviewing them: PCSat, which the quantifier tests have to use, accepts the malformed query instead of rejecting it, so the `pass` files verify even without this change — under Z3 they fail loudly. What they do pin under CI is the ICE: with the sort collected and the registration reverted, `pass/annot_exists_enum_binder.rs` panics. I could not find a program that pins the declaration itself through PCSat; if you would rather have that covered, a unit test over `FormatContext::from_system` with a hand-built system would do it, and I am happy to add one.

---
_Generated by [Claude Code](https://claude.ai/code/session_015HS3g7RPk9yEa3DuGQ9kTo)_