### PR TITLE
Traverse types once when relating them invariantly

### DIFF
--- a/src/rty/subtyping.rs
+++ b/src/rty/subtyping.rs
@@ -48,13 +48,6 @@ pub trait Subtyping {
         got: &RefinedType<T>,
         expected: &RefinedType<U>,
     ) -> Vec<chc::Clause>;
-
-    #[must_use]
-    fn relate_equal_refined_type<T: chc::Var, U: chc::Var>(
-        &self,
-        got: &RefinedType<T>,
-        expected: &RefinedType<U>,
-    ) -> Vec<chc::Clause>;
 }
 
 impl<C> Subtyping for C
@@ -66,70 +59,7 @@ where
         T: chc::Var,
         U: chc::Var,
     {
-        tracing::debug!(got = %got.display(), expected = %expected.display(), "sub_type");
-
-        let mut clauses = Vec::new();
-        match (got, expected) {
-            (Type::Int, Type::Int)
-            | (Type::Bool, Type::Bool)
-            | (Type::String, Type::String)
-            | (Type::Never, Type::Never) => {}
-            (Type::Enum(got), Type::Enum(expected)) if got.symbol() == expected.symbol() => {
-                for (got_ty, expected_ty) in got.args.iter().zip(expected.args.iter()) {
-                    let cs = self.relate_sub_refined_type(got_ty, expected_ty);
-                    clauses.extend(cs);
-                }
-            }
-            (Type::Tuple(got), Type::Tuple(expected))
-                if got.elems.len() == expected.elems.len() =>
-            {
-                for (got_ty, expected_ty) in got.elems.iter().zip(expected.elems.iter()) {
-                    let cs = self.relate_sub_refined_type(got_ty, expected_ty);
-                    clauses.extend(cs);
-                }
-            }
-            (Type::Pointer(got), Type::Pointer(expected)) if got.kind == expected.kind => {
-                match got.kind {
-                    PointerKind::Ref(RefKind::Immut) => {
-                        let cs = self.relate_sub_refined_type(&got.elem, &expected.elem);
-                        clauses.extend(cs);
-                    }
-                    PointerKind::Own | PointerKind::Ref(RefKind::Mut) => {
-                        let cs = self.relate_equal_refined_type(&got.elem, &expected.elem);
-                        clauses.extend(cs);
-                    }
-                }
-            }
-            (Type::Function(got), Type::Function(expected))
-                if got.params.len() == expected.params.len() =>
-            {
-                let mut builder = chc::ClauseBuilder::default();
-                for (param_idx, param_rty) in got.params.iter_enumerated() {
-                    let param_sort = param_rty.ty.to_sort();
-                    if !param_sort.is_singleton() {
-                        builder.add_mapped_var(param_idx, param_sort);
-                    }
-                }
-                for (got_ty, expected_ty) in got.params.iter().zip(expected.params.iter()) {
-                    let cs = builder.relate_sub_refined_type(expected_ty, got_ty);
-                    clauses.extend(cs);
-                }
-                let cs = builder.relate_sub_refined_type(&got.ret, &expected.ret);
-                clauses.extend(cs);
-            }
-            (Type::Array(got), Type::Array(expected)) => {
-                let cs1 = self.relate_sub_refined_type(&got.index, &expected.index);
-                clauses.extend(cs1);
-                let cs2 = self.relate_sub_refined_type(&got.elem, &expected.elem);
-                clauses.extend(cs2);
-            }
-            _ => panic!(
-                "inconsistent types: got={}, expected={}",
-                got.display(),
-                expected.display()
-            ),
-        }
-        clauses
+        relate_type(self, got, expected, Relation::Sub)
     }
 
     fn relate_sub_refined_type<T, U>(
@@ -141,34 +71,121 @@ where
         T: chc::Var,
         U: chc::Var,
     {
-        tracing::debug!(got = %got.display(), expected = %expected.display(), "sub_refined_type");
+        relate_refined_type(self, got, expected, Relation::Sub)
+    }
+}
 
-        let mut clauses = self.relate_sub_type(&got.ty, &expected.ty);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Relation {
+    Sub,
+    Equal,
+}
 
-        let cs = self
+#[must_use]
+fn relate_type<C, T, U>(
+    scope: &C,
+    got: &Type<T>,
+    expected: &Type<U>,
+    relation: Relation,
+) -> Vec<chc::Clause>
+where
+    C: ClauseScope,
+    T: chc::Var,
+    U: chc::Var,
+{
+    tracing::debug!(got = %got.display(), expected = %expected.display(), ?relation, "relate_type");
+
+    let mut clauses = Vec::new();
+    match (got, expected) {
+        (Type::Int, Type::Int)
+        | (Type::Bool, Type::Bool)
+        | (Type::String, Type::String)
+        | (Type::Never, Type::Never) => {}
+        (Type::Enum(got), Type::Enum(expected)) if got.symbol() == expected.symbol() => {
+            for (got_ty, expected_ty) in got.args.iter().zip(expected.args.iter()) {
+                let cs = relate_refined_type(scope, got_ty, expected_ty, relation);
+                clauses.extend(cs);
+            }
+        }
+        (Type::Tuple(got), Type::Tuple(expected)) if got.elems.len() == expected.elems.len() => {
+            for (got_ty, expected_ty) in got.elems.iter().zip(expected.elems.iter()) {
+                let cs = relate_refined_type(scope, got_ty, expected_ty, relation);
+                clauses.extend(cs);
+            }
+        }
+        (Type::Pointer(got), Type::Pointer(expected)) if got.kind == expected.kind => {
+            let elem_relation = match got.kind {
+                PointerKind::Ref(RefKind::Immut) => relation,
+                PointerKind::Own | PointerKind::Ref(RefKind::Mut) => Relation::Equal,
+            };
+            let cs = relate_refined_type(scope, &got.elem, &expected.elem, elem_relation);
+            clauses.extend(cs);
+        }
+        (Type::Function(got), Type::Function(expected))
+            if got.params.len() == expected.params.len() =>
+        {
+            let mut builder = chc::ClauseBuilder::default();
+            for (param_idx, param_rty) in got.params.iter_enumerated() {
+                let param_sort = param_rty.ty.to_sort();
+                if !param_sort.is_singleton() {
+                    builder.add_mapped_var(param_idx, param_sort);
+                }
+            }
+            for (got_ty, expected_ty) in got.params.iter().zip(expected.params.iter()) {
+                let cs = relate_refined_type(&builder, expected_ty, got_ty, relation);
+                clauses.extend(cs);
+            }
+            let cs = relate_refined_type(&builder, &got.ret, &expected.ret, relation);
+            clauses.extend(cs);
+        }
+        (Type::Array(got), Type::Array(expected)) => {
+            let cs1 = relate_refined_type(scope, &got.index, &expected.index, relation);
+            clauses.extend(cs1);
+            let cs2 = relate_refined_type(scope, &got.elem, &expected.elem, relation);
+            clauses.extend(cs2);
+        }
+        _ => panic!(
+            "inconsistent types: got={}, expected={}",
+            got.display(),
+            expected.display()
+        ),
+    }
+    clauses
+}
+
+#[must_use]
+fn relate_refined_type<C, T, U>(
+    scope: &C,
+    got: &RefinedType<T>,
+    expected: &RefinedType<U>,
+    relation: Relation,
+) -> Vec<chc::Clause>
+where
+    C: ClauseScope,
+    T: chc::Var,
+    U: chc::Var,
+{
+    tracing::debug!(got = %got.display(), expected = %expected.display(), ?relation, "relate_refined_type");
+
+    let mut clauses = relate_type(scope, &got.ty, &expected.ty, relation);
+
+    let cs = scope
+        .build_clause()
+        .with_value_var(&got.ty)
+        .add_body(got.refinement.clone())
+        .head(expected.refinement.clone());
+    clauses.extend(cs);
+
+    if relation == Relation::Equal {
+        let cs = scope
             .build_clause()
-            .with_value_var(&got.ty)
-            .add_body(got.refinement.clone())
-            .head(expected.refinement.clone());
+            .with_value_var(&expected.ty)
+            .add_body(expected.refinement.clone())
+            .head(got.refinement.clone());
         clauses.extend(cs);
-        clauses
     }
 
-    fn relate_equal_refined_type<T, U>(
-        &self,
-        got: &RefinedType<T>,
-        expected: &RefinedType<U>,
-    ) -> Vec<chc::Clause>
-    where
-        T: chc::Var,
-        U: chc::Var,
-    {
-        tracing::debug!(got = %got.display(), expected = %expected.display(), "equal_refined_type");
-
-        let mut clauses = self.relate_sub_refined_type(got, expected);
-        clauses.extend(self.relate_sub_refined_type(expected, got));
-        clauses
-    }
+    clauses
 }
 
 #[must_use]


### PR DESCRIPTION
Relating two types invariantly was expressed as subtyping in both directions:

```rust
let mut clauses = self.relate_sub_refined_type(got, expected);
clauses.extend(self.relate_sub_refined_type(expected, got));
```

`relate_sub_refined_type` walks the whole type structure, so this traverses it twice, and every owning or mutable pointer found inside relates its referent invariantly again. The number of clauses emitted for a refinement therefore doubles per pointer layer above it.

The two directions do not derive different constraints. Writing `S` for `relate_sub_refined_type`, `E` for `relate_equal_refined_type` and `R` for `relate_sub_type`:

```
S(A,B) = R(A.ty, B.ty) ++ [ A.ref => B.ref ]
E(A,B) = S(A,B) ++ S(B,A)
R(own X, own Y) = E(X, Y)              -- and likewise for &mut
```

`E` is symmetric by its definition, so `E(own X, own Y)` contains `E(X,Y)` and `E(Y,X)` — the same multiset twice. The direction only distinguishes anything at a covariant position, and every position below an owning or mutable pointer is invariant again, so the second direction just re-derives the constraints of the first.

This walks the type once, carrying the relation to derive, and emits both implications at the positions where the refinements must agree.

## Effect

Measured on a `&mut self` trait method over `Option<i32>` (`own (&mut (own Option<{int | p3}>, ))`, three such pointer layers), and on the same program with one more struct nesting:

| | before | after |
|---|---|---|
| three pointer layers | 29 clauses / 59.9 KB | 14 clauses / 28.0 KB |
| four pointer layers | 49 clauses / 115.0 KB | 14 clauses / 31.6 KB |

Both had 12 distinct clauses throughout. The count no longer grows with nesting depth. No change on the existing UI tests' output, which do not nest pointers above a refinement.

Two duplicates remain in that example, of the form `p3 v <= ... /\ p3 v`: both sides of an invariant position happen to carry the same predicate variable, so the two implications coincide. That is inherent to relating a position invariantly and is bounded by 2 regardless of depth. Dropping those would mean treating a clause whose head occurs in its own body as a nop, which needs `PartialEq` on `Atom`/`Term`/`Formula`; left out of this change.

## Other changes

`relate_equal_refined_type` had no callers outside this module once the recursion stopped going through it, so it is dropped from the `Subtyping` trait.

## Testing

`cargo test` (334 UI tests + unit and doc tests), `cargo clippy -- -D warnings`, `cargo fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEtrgExrszb8aBUEGASPeE


---
_Generated by [Claude Code](https://claude.ai/code/session_01PEtrgExrszb8aBUEGASPeE)_